### PR TITLE
[feat]: Implement Notice View UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:green_field/src/model/notice.dart';
 import 'package:green_field/src/model/recruit.dart';
 import 'package:green_field/src/model/user.dart';
 import 'package:green_field/src/views/home/home_view.dart';
+import 'package:green_field/src/views/home/notice_view.dart';
 import 'package:green_field/src/views/onboarding_view.dart';
 import 'firebase_options.dart';
 import 'package:green_field/src/components/greenfield_confirm_button.dart';
@@ -44,28 +45,7 @@ class MyApp extends StatelessWidget {
         primaryColor: AppColorsTheme().gfMainColor,
         scaffoldBackgroundColor: AppColorsTheme().gfBackGroundColor,
       ),
-      home: HomeView(
-          user: User(
-            id: '12345',
-            simpleLoginId: 'user123',
-            userType: 'student', // Optional, defaults to "student"
-            campus: '관악캠퍼스',
-            course: '컴퓨터공학',
-            name: '홍길동',
-            createDate: DateTime.now(), // Current date and time
-            lastLoginDate: DateTime.now().subtract(Duration(days: 1)), // Last login was yesterday
-          ),
-        post: Post(
-          id: 'post_001',
-          creatorId: 'user_123',
-          creatorCampus: '관악캠퍼스',
-          createdAt: DateTime.now(), // 현재 날짜와 시간
-          title: '새로운 식당 오픈 안내',
-          body: '새로운 식당 어부사시가 오픈했습니다. 많은 이용 부탁드립니다!',
-          like: ['user_456', 'user_789'], // 좋아요를 누른 사용자 ID 목록
-          images: ['https://example.com/image1.jpg', 'https://example.com/image2.jpg'], // 이미지 URL 목록
-        )
-      ),
+      home: NoticeView(notice: [])
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,27 +1,8 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:green_field/src/components/greenfield_comment_widget.dart';
-import 'package:green_field/src/components/greenfield_content_widget.dart';
-import 'package:green_field/src/components/greenfield_edit_section.dart';
-import 'package:green_field/src/components/greenfield_recruit_list.dart';
-import 'package:green_field/src/components/greenfield_text_field.dart';
-import 'package:green_field/src/enums/feature_type.dart';
-import 'package:green_field/src/model/notice.dart';
-import 'package:green_field/src/model/recruit.dart';
-import 'package:green_field/src/model/user.dart';
-import 'package:green_field/src/views/home/home_view.dart';
-import 'package:green_field/src/views/home/notice_view.dart';
-import 'package:green_field/src/views/onboarding_view.dart';
+import 'package:green_field/src/views/notice/notice_view.dart';
 import 'firebase_options.dart';
-import 'package:green_field/src/components/greenfield_confirm_button.dart';
-import 'package:green_field/src/components/greenfield_app_bar.dart';
-import 'package:green_field/src/components/greenfield_list.dart';
-import 'package:green_field/src/components/greenfield_user_info_widget.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
-
-import 'src/model/post.dart';
-import 'src/views/login_view.dart';
 
 void main() async {
   // Flutter 프레임워크가 초기화되기 전에 Firebase 초기화

--- a/lib/src/components/greenfield_app_bar.dart
+++ b/lib/src/components/greenfield_app_bar.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import '../design_system/app_colors.dart';
 import '../design_system/app_texts.dart';
@@ -5,19 +6,40 @@ import '../design_system/app_texts.dart';
 class GreenFieldAppBar extends StatelessWidget implements PreferredSizeWidget {
   final Color backgGroundColor;
   final String title;
-  final Widget? leading;
+  final Widget? leadingIcon;
+  final Function()? leadingAction;
+  final bool? noLeadingIcon;
   final List<Widget>? actions;
 
   const GreenFieldAppBar({
     super.key,
     required this.backgGroundColor,
     required this.title,
-    this.leading,
     this.actions,
+    this.leadingIcon,
+    this.leadingAction,
+    this.noLeadingIcon,
   });
 
   @override
   Widget build(BuildContext context) {
+    Widget? leading;
+    if (leadingAction != null || leadingIcon != null) {
+      leading = CupertinoButton(child: leadingIcon ?? Icon(Icons.arrow_left),
+          onPressed: leadingAction);
+    } else {
+      leading = CupertinoButton(
+          padding: EdgeInsets.zero,
+          child: const Icon(
+            size: 24,
+            CupertinoIcons.back,
+            color: Colors.grey,
+          ),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        );
+    }
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: AppBar(

--- a/lib/src/components/greenfield_content_widget.dart
+++ b/lib/src/components/greenfield_content_widget.dart
@@ -31,42 +31,59 @@ class GreenFieldContentWidget extends StatelessWidget {
             Text(
               title,
               style: AppTextsTheme.main().gfHeading1.copyWith(
-                color: AppColorsTheme().gfBlackColor
-              )
+                color: AppColorsTheme().gfBlackColor,
+              ),
             ),
             SizedBox(height: 17),
             Text(
               bodyText,
-                style: AppTextsTheme.main().gfCaption2.copyWith(
-                    color: AppColorsTheme().gfBlackColor
-                )
-            ),
-            SizedBox(height: 17),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                children: imageAssets.map((imageUrl) {
-                  if (imageUrl != null) {
-                    return Padding(
-                      padding: const EdgeInsets.only(right: 10.0),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: Image.network(
-                          imageUrl,
-                          width: 120,
-                          height: 120,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                    );
-                  } else {
-                    return Container();
-                  }
-                }).toList(),
+              style: AppTextsTheme.main().gfCaption2Light.copyWith(
+                color: AppColorsTheme().gfBlackColor,
               ),
             ),
-            if (imageAssets.isNotEmpty)
-              SizedBox(height: 17),
+            SizedBox(height: 17),
+            // 이미지 표시 부분 수정
+            if (imageAssets.length == 1 && imageAssets[0] != null)
+              Container(
+                width: double.infinity,
+                height: MediaQuery.of(context).size.width,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.network(
+                    imageAssets[0]!,
+                    width: double.infinity,
+                    height: double.infinity,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              )
+            else
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: imageAssets.map((imageUrl) {
+                    if (imageUrl != null) {
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 10.0),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            width: 120, // 정사각형 너비
+                            height: 120, // 정사각형 높이
+                            child: Image.network(
+                              imageUrl,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                        ),
+                      );
+                    } else {
+                      return Container();
+                    }
+                  }).toList(),
+                ),
+              ),
+            if (imageAssets.isNotEmpty) SizedBox(height: 17),
             Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [

--- a/lib/src/components/greenfield_list.dart
+++ b/lib/src/components/greenfield_list.dart
@@ -58,7 +58,7 @@ class GreenFieldList extends StatelessWidget {
                             content,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: AppTextsTheme.main().gfCaption2.copyWith(
+                            style: AppTextsTheme.main().gfCaption2Light.copyWith(
                               color: AppColorsTheme().gfBlackColor,
                             ),
                           ),

--- a/lib/src/components/greenfield_user_info_widget.dart
+++ b/lib/src/components/greenfield_user_info_widget.dart
@@ -2,15 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
+import 'package:green_field/src/enums/feature_type.dart';
 
 class GreenfieldUserInfoWidget extends StatelessWidget {
-  final String type; // 타입 (notice, post)
+  final FeatureType featureType;
   final String campus;
   final String createTimeText;
 
   const GreenfieldUserInfoWidget({
     super.key,
-    required this.type,
+    required this.featureType,
     required this.campus,
     required this.createTimeText,
   });
@@ -30,7 +31,7 @@ class GreenfieldUserInfoWidget extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Image.asset(
-              type == 'notice' ? AppIcons.sesac : AppIcons.profile,
+              featureType == FeatureType.notice ? AppIcons.sesac : AppIcons.profile,
               width: 40,
               height: 40,
               fit: BoxFit.cover,
@@ -43,9 +44,9 @@ class GreenfieldUserInfoWidget extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Text(
-                    type == 'notice' ? campus :'익명($campus)',
+                    featureType  == FeatureType.notice ? campus :'익명($campus)',
                     style: AppTextsTheme.main().gfHeading3.copyWith(
-                      color: type == 'notice' ? AppColorsTheme().gfMainColor : AppColorsTheme().gfGray800Color,
+                      color: featureType  == FeatureType.notice ? AppColorsTheme().gfMainColor : AppColorsTheme().gfGray800Color,
                     ),
                   ),
                   Text(

--- a/lib/src/components/greenfield_user_info_widget.dart
+++ b/lib/src/components/greenfield_user_info_widget.dart
@@ -48,7 +48,6 @@ class GreenfieldUserInfoWidget extends StatelessWidget {
                       color: type == 'notice' ? AppColorsTheme().gfMainColor : AppColorsTheme().gfGray800Color,
                     ),
                   ),
-                  SizedBox(height: 3),
                   Text(
                     createTimeText,
                     style: AppTextsTheme.main().gfBody5.copyWith(

--- a/lib/src/design_system/app_texts.dart
+++ b/lib/src/design_system/app_texts.dart
@@ -18,6 +18,7 @@ class AppTextsTheme extends ThemeExtension<AppTextsTheme> {
   final TextStyle gfBody5;
   final TextStyle gfCaption1;
   final TextStyle gfCaption2;
+  final TextStyle gfCaption2Light;
   final TextStyle gfCaption3;
   final TextStyle gfCaption4;
   final TextStyle gfCaption5;
@@ -38,6 +39,7 @@ class AppTextsTheme extends ThemeExtension<AppTextsTheme> {
     required this.gfBody5,
     required this.gfCaption1,
     required this.gfCaption2,
+    required this.gfCaption2Light,
     required this.gfCaption3,
     required this.gfCaption4,
     required this.gfCaption5,
@@ -134,6 +136,12 @@ class AppTextsTheme extends ThemeExtension<AppTextsTheme> {
       fontSize: 12.6,
       height: 17.5 / 12.6,
     ),
+    gfCaption2Light: TextStyle(
+      fontFamily: _baseFamily,
+      fontWeight: FontWeight.w400,
+      fontSize: 12.6,
+      height: 17.5 / 12.6,
+    ),
     gfCaption3: TextStyle(
       fontFamily: _baseFamily,
       fontWeight: FontWeight.w500,
@@ -172,6 +180,7 @@ class AppTextsTheme extends ThemeExtension<AppTextsTheme> {
       gfBody5: gfBody5,
       gfCaption1: gfCaption1,
       gfCaption2: gfCaption2,
+      gfCaption2Light: gfCaption2Light,
       gfCaption3: gfCaption3,
       gfCaption4: gfCaption4,
       gfCaption5: gfCaption5,

--- a/lib/src/enums/feature_type.dart
+++ b/lib/src/enums/feature_type.dart
@@ -1,2 +1,2 @@
 
-enum FeatureType { post, recruit }
+enum FeatureType { post, recruit, notice }

--- a/lib/src/views/home/notice_view.dart
+++ b/lib/src/views/home/notice_view.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:green_field/src/components/greenfield_app_bar.dart';
+import 'package:green_field/src/components/greenfield_list.dart';
+import 'package:green_field/src/design_system/app_colors.dart';
+
+import '../../model/notice.dart';
+
+class NoticeView extends StatefulWidget {
+  final List<Notice> notice;
+
+  const NoticeView({super.key, required this.notice});
+
+  @override
+  _NoticeViewState createState() => _NoticeViewState();
+}
+
+class _NoticeViewState extends State<NoticeView> {
+  final List<Notice> notices = [
+    Notice(
+      id: '1',
+      creatorId: 'user_001',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 1',
+      body: '공지사항 1의 내용입니다.',
+      like: ['user_002', 'user_003'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 1)),
+    ),
+    Notice(
+      id: '2',
+      creatorId: 'user_002',
+      userCampus: '캠퍼스 B',
+      title: '공지사항 2',
+      body: '공지사항 2의 내용입니다.',
+      like: ['user_001'],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 2)),
+    ),
+    Notice(
+      id: '3',
+      creatorId: 'user_003',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 3',
+      body: '공지사항 3의 내용입니다.',
+      like: [],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 3)),
+    ),
+    Notice(
+      id: '4',
+      creatorId: 'user_004',
+      userCampus: '캠퍼스 C',
+      title: '공지사항 4',
+      body: '공지사항 4의 내용입니다.',
+      like: ['user_001', 'user_002', 'user_003'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 4)),
+    ),
+    Notice(
+      id: '5',
+      creatorId: 'user_005',
+      userCampus: '캠퍼스 B',
+      title: '공지사항 5',
+      body: '공지사항 5의 내용입니다.',
+      like: ['user_006'],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 5)),
+    ),
+    Notice(
+      id: '6',
+      creatorId: 'user_006',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 6',
+      body: '공지사항 6의 내용입니다.',
+      like: ['user_001', 'user_005'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 6)),
+    ),
+    Notice(
+      id: '7',
+      creatorId: 'user_007',
+      userCampus: '캠퍼스 C',
+      title: '공지사항 7',
+      body: '공지사항 7의 내용입니다.',
+      like: [],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 7)),
+    ),
+    Notice(
+      id: '8',
+      creatorId: 'user_008',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 8',
+      body: '공지사항 8의 내용입니다.',
+      like: ['user_002'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 8)),
+    ),
+    Notice(
+      id: '9',
+      creatorId: 'user_009',
+      userCampus: '캠퍼스 B',
+      title: '공지사항 9',
+      body: '공지사항 9의 내용입니다.',
+      like: ['user_001', 'user_003'],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 9)),
+    ),
+    Notice(
+      id: '10',
+      creatorId: 'user_010',
+      userCampus: '캠퍼스 C',
+      title: '공지사항 10',
+      body: '공지사항 10의 내용입니다.',
+      like: ['user_004'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 10)),
+    ),
+    Notice(
+      id: '11',
+      creatorId: 'user_011',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 11',
+      body: '공지사항 11의 내용입니다.',
+      like: ['user_002', 'user_005'],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 11)),
+    ),
+    Notice(
+      id: '12',
+      creatorId: 'user_012',
+      userCampus: '캠퍼스 B',
+      title: '공지사항 12',
+      body: '공지사항 12의 내용입니다.',
+      like: [],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 12)),
+    ),
+    Notice(
+      id: '13',
+      creatorId: 'user_013',
+      userCampus: '캠퍼스 C',
+      title: '공지사항 13',
+      body: '공지사항 13의 내용입니다.',
+      like: ['user_001'],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 13)),
+    ),
+    Notice(
+      id: '14',
+      creatorId: 'user_014',
+      userCampus: '캠퍼스 A',
+      title: '공지사항 14',
+      body: '공지사항 14의 내용입니다.',
+      like: ['user_003', 'user_006'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      createdAt: DateTime.now().subtract(Duration(days: 14)),
+    ),
+    Notice(
+      id: '15',
+      creatorId: 'user_015',
+      userCampus: '캠퍼스 B',
+      title: '공지사항 15',
+      body: '공지사항 15의 내용입니다.',
+      like: [],
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 15)),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColorsTheme().gfWhiteColor,
+      appBar: GreenFieldAppBar(
+        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        title: "공지사항",
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.grey),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: ListView.builder(
+        itemCount: notices.length,
+        itemBuilder: (context, index) {
+          final notice = notices[index];
+          return GreenFieldList(
+            title: notice.title,
+            content: notice.body,
+            date: notice.createdAt.toString(),
+            campus: notice.userCampus,
+            imageUrl: notice.images != null && notice.images!.isNotEmpty ? notice.images![0] : "",
+            likes: notice.like.length,
+            commentCount: 0,
+            onTap: () {
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/src/views/notice/notice_deatil_view.dart
+++ b/lib/src/views/notice/notice_deatil_view.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/components/greenfield_app_bar.dart';
+import 'package:green_field/src/components/greenfield_content_widget.dart';
+import 'package:green_field/src/components/greenfield_user_info_widget.dart';
+import 'package:green_field/src/design_system/app_colors.dart';
+
+import '../../model/notice.dart';
+
+class NoticeDetailView extends StatefulWidget {
+  final Notice notice;
+
+  const NoticeDetailView({super.key, required this.notice});
+
+  @override
+  _NoticeDetailViewState createState() => _NoticeDetailViewState();
+}
+
+class _NoticeDetailViewState extends State<NoticeDetailView> {
+  @override
+  Widget build(BuildContext context) {
+    final notice = widget.notice;
+
+    return Scaffold(
+      backgroundColor: AppColorsTheme().gfWhiteColor,
+      appBar: GreenFieldAppBar(
+        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        title: "공지사항",
+        leading: CupertinoButton(
+          padding: EdgeInsets.zero,
+          child: const Icon(CupertinoIcons.back, color: Colors.grey), // Cupertino 아이콘 사용
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            child: GreenfieldUserInfoWidget(
+              type: 'notice',
+              campus: notice.userCampus,
+              createTimeText: '${notice.createdAt.year}-${notice.createdAt.month}-${notice.createdAt.day}',
+            ),
+          ),
+          GreenFieldContentWidget(
+            title: notice.title,
+            bodyText: notice.body,
+            imageAssets: notice.images != null && notice.images!.isNotEmpty ? notice.images! : [],
+            likes: notice.like.length,
+            commentCount: 0,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/views/notice/notice_deatil_view.dart
+++ b/lib/src/views/notice/notice_deatil_view.dart
@@ -27,13 +27,6 @@ class _NoticeDetailViewState extends State<NoticeDetailView> {
       appBar: GreenFieldAppBar(
         backgGroundColor: AppColorsTheme().gfWhiteColor,
         title: "공지사항",
-        leading: CupertinoButton(
-          padding: EdgeInsets.zero,
-          child: const Icon(CupertinoIcons.back, color: Colors.grey), // Cupertino 아이콘 사용
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
       ),
       body: SingleChildScrollView(
         child: Column(

--- a/lib/src/views/notice/notice_deatil_view.dart
+++ b/lib/src/views/notice/notice_deatil_view.dart
@@ -4,6 +4,7 @@ import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_content_widget.dart';
 import 'package:green_field/src/components/greenfield_user_info_widget.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/enums/feature_type.dart';
 
 import '../../model/notice.dart';
 
@@ -34,25 +35,27 @@ class _NoticeDetailViewState extends State<NoticeDetailView> {
           },
         ),
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16.0),
-            child: GreenfieldUserInfoWidget(
-              type: 'notice',
-              campus: notice.userCampus,
-              createTimeText: '${notice.createdAt.year}-${notice.createdAt.month}-${notice.createdAt.day}',
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start, // 왼쪽 정렬
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16.0),
+              child: GreenfieldUserInfoWidget(
+                featureType: FeatureType.notice,
+                campus: notice.userCampus,
+                createTimeText: '${notice.createdAt.year}-${notice.createdAt.month}-${notice.createdAt.day}',
+              ),
             ),
-          ),
-          GreenFieldContentWidget(
-            title: notice.title,
-            bodyText: notice.body,
-            imageAssets: notice.images != null && notice.images!.isNotEmpty ? notice.images! : [],
-            likes: notice.like.length,
-            commentCount: 0,
-          ),
-        ],
+            GreenFieldContentWidget(
+              title: notice.title,
+              bodyText: notice.body,
+              imageAssets: notice.images != null && notice.images!.isNotEmpty ? notice.images! : [],
+              likes: notice.like.length,
+              commentCount: 0,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/views/notice/notice_view.dart
+++ b/lib/src/views/notice/notice_view.dart
@@ -177,13 +177,7 @@ class _NoticeViewState extends State<NoticeView> {
       appBar: GreenFieldAppBar(
         backgGroundColor: AppColorsTheme().gfWhiteColor,
         title: "공지사항",
-        leading: CupertinoButton(
-          padding: EdgeInsets.zero,
-          child: const Icon(CupertinoIcons.back, color: Colors.grey), // Cupertino 아이콘 사용
-          onPressed: () {
-            Navigator.pop(context);
-          },
-        ),
+        leadingIcon: SizedBox(),
       ),
       body: ListView.builder(
         itemCount: notices.length,

--- a/lib/src/views/notice/notice_view.dart
+++ b/lib/src/views/notice/notice_view.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_list.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 
 import '../../model/notice.dart';
+import 'notice_deatil_view.dart';
 
 class NoticeView extends StatefulWidget {
   final List<Notice> notice;
@@ -20,10 +22,10 @@ class _NoticeViewState extends State<NoticeView> {
       id: '1',
       creatorId: 'user_001',
       userCampus: '캠퍼스 A',
-      title: '공지사항 1',
-      body: '공지사항 1의 내용입니다.',
+      title: '중식당 추가 안내',
+      body: '안녕하세요 서울 경제 진흥원 관악캠퍼스 매니저입니다.최근 식당 늘어난 걸 모르시는 분들이 많은 것 같다고 하셔서 (저도 몰랐네용) 홍보차 메세지 남깁니다!![어부사시가] https://naver.me/GFYaoQhg[프랭크버거] https://naver.me/xgG2WAbh  아! 그리고 러닝메이트 식사는, 제로페이 가맹점 이용 건에 대해서 협의중이라 당분간은 (아마도 한 달.. 정도?) 장부 이용해야 할 것 같다고 첨언 주셨습니다!  다음 주 한 주도 건강하고 즐겁게 보내세요',
       like: ['user_002', 'user_003'],
-      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
+      images: ['https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg','https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg','https://images.dog.ceo/breeds/boxer/n02108089_2831.jpg'],
       createdAt: DateTime.now().subtract(Duration(days: 1)),
     ),
     Notice(
@@ -175,8 +177,9 @@ class _NoticeViewState extends State<NoticeView> {
       appBar: GreenFieldAppBar(
         backgGroundColor: AppColorsTheme().gfWhiteColor,
         title: "공지사항",
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: Colors.grey),
+        leading: CupertinoButton(
+          padding: EdgeInsets.zero,
+          child: const Icon(CupertinoIcons.back, color: Colors.grey), // Cupertino 아이콘 사용
           onPressed: () {
             Navigator.pop(context);
           },
@@ -189,12 +192,18 @@ class _NoticeViewState extends State<NoticeView> {
           return GreenFieldList(
             title: notice.title,
             content: notice.body,
-            date: notice.createdAt.toString(),
+            date: '${notice.createdAt.year}-${notice.createdAt.month}-${notice.createdAt.day}',
             campus: notice.userCampus,
             imageUrl: notice.images != null && notice.images!.isNotEmpty ? notice.images![0] : "",
             likes: notice.like.length,
             commentCount: 0,
             onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => NoticeDetailView(notice: notice),
+                ),
+              );
             },
           );
         },


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
### **NoticeView**
`NoticeView`는 공지사항 목록을 표시하는 Scaffold입니다.  여러 개의 `Notice` 객체를 받아 리스트 형태로 표시하며, 각 공지사항 항목을 클릭하면 해당 공지사항의 세부 정보를 보여주는 화면으로 이동합니다.

#### 주요 속성
- **`notice`**: `List<Notice>` - 공지사항 정보를 담고 있는 `Notice` 객체의 리스트.
  
#### 주요 기능
- **공지사항 목록 표시**: `ListView.builder`를 사용하여 공지사항 목록을 동적으로 생성하고 표시합니다.
- **상세보기 네비게이션**: 각 공지사항 항목을 클릭하면 `NoticeDetailView`로 이동하여 해당 공지사항의 세부 정보를 보여줍니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 공지사항 목록의 상태를 관리할 수 있습니다.

#### UI 구성 요소
- **AppBar**: `GreenFieldAppBar`를 사용하여 상단에 제목과 뒤로 가기 버튼을 포함한 앱 바를 설정합니다.
- **공지사항 항목**: 각 공지사항은 `GreenFieldList` 컴포넌트를 통해 표시되며, 제목, 내용, 날짜, 캠퍼스, 이미지 URL, 좋아요 수, 댓글 수 등의 정보를 전달합니다.

### **NoticeDetailView**
`NoticeDetailView`는 선택된 공지사항의 세부 정보를 표시하는 Scaffold입니다.  특정 `Notice` 객체를 받아 해당 공지사항의 제목, 내용, 작성자 정보 및 이미지를 보여줍니다.

#### 주요 속성
- **`notice`**: `Notice` - 공지사항의 세부 정보를 담고 있는 `Notice` 객체.

#### 주요 기능
- **공지사항 세부 정보 표시**: 선택된 공지사항의 제목, 내용, 작성자 정보 및 이미지를 표시합니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 공지사항의 상태를 관리할 수 있습니다.

#### UI 구성 요소
- **AppBar**: `GreenFieldAppBar`를 사용하여 상단에 제목과 뒤로 가기 버튼을 포함한 앱 바를 설정합니다.
- **작성자 정보**: `GreenfieldUserInfoWidget`을 사용하여 공지사항의 작성자 정보와 작성 날짜를 표시합니다.
- **내용 표시**: `GreenFieldContentWidget`을 사용하여 공지사항의 제목, 내용, 이미지, 좋아요 수 등을 표시합니다.

#### 이미지 표시 방식
- **여러 이미지**: 이미지가 여러개여서 화면 보다 넓이를 더 많이 차지 하면, `SingleChildScrollView`를 사용하여 가로 스크롤이 가능하도록 설정합니다. 사용자는 이미지를 좌우로 스크롤하여 모든 이미지를 확인할 수 있습니다.
- **하나의 이미지**: 이미지가 1개일 경우, 해당 이미지는 화면 너비에 꽉 차게 표시됩니다. 이때 이미지는 정사각형 형태로 유지되며, 비율을 유지하면서 화면을 가득 채웁니다.


<br>

<br>


## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|Notice|<img src = "https://github.com/user-attachments/assets/da51cb91-f8ca-40cc-971a-aeaa49357f54" width ="750">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이
나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
