### PR TITLE
[feat]: Implement Recruit View UI

### DIFF
--- a/lib/src/components/greenfield_confirm_button.dart
+++ b/lib/src/components/greenfield_confirm_button.dart
@@ -21,14 +21,15 @@ class GreenFieldConfirmButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CupertinoButton(
-      onPressed: isAble ? onPressed : null, // 버튼 클릭 시 동작
-      color: isAble ? backGroundColor : AppColorsTheme().gfGray300Color, // 배경 색상
-      borderRadius: BorderRadius.circular(8.0), // 모서리 둥글게
-      padding: EdgeInsets.zero, // 패딩을 0으로 설정하여 크기 조정
-      child: SizedBox(
-        width: MediaQuery.of(context).size.width - 32, // 화면 너비에 맞춤
-        height: 56.0, // 높이를 56으로 설정
-        child: Center( // 텍스트를 중앙에 정렬
+      onPressed: isAble ? onPressed : null,
+      padding: EdgeInsets.zero,
+      child: Container(
+        decoration: BoxDecoration(
+          color: backGroundColor,
+          borderRadius: BorderRadius.circular(8.0),
+        ),
+        height: 56.0,
+        child: Center(
           child: Text(
             text,
             style: AppTextsTheme.main().gfTitle1.copyWith(

--- a/lib/src/components/greenfield_content_widget.dart
+++ b/lib/src/components/greenfield_content_widget.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/model/recruit.dart';
 
 import '../design_system/app_colors.dart';
 import '../design_system/app_icons.dart';
 import '../design_system/app_texts.dart';
 
 class GreenFieldContentWidget extends StatelessWidget {
+  final FeatureType? featureType;
   final String title;
   final String bodyText;
   final List<String?> imageAssets;
-  final int likes;
-  final int commentCount;
+  final int? likes;
+  final int? commentCount;
+  final Recruit? recruit;
 
   GreenFieldContentWidget({
     super.key,
+    this.featureType,
     required this.title,
     required this.bodyText,
     required this.imageAssets,
-    required this.likes,
-    required this.commentCount,
+    this.likes,
+    this.commentCount,
+    this.recruit
   });
 
   @override
@@ -84,7 +90,8 @@ class GreenFieldContentWidget extends StatelessWidget {
                 ),
               ),
             if (imageAssets.isNotEmpty) SizedBox(height: 17),
-            Row(
+            featureType != FeatureType.recruit
+                ? Row(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 Row(
@@ -123,7 +130,109 @@ class GreenFieldContentWidget extends StatelessWidget {
                   ],
                 ),
               ],
-            ),
+            )
+                : Row(
+              children: [
+                Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      color: AppColorsTheme().gfGray800Color, // 테두리 색상
+                      width: 1, // 테두리 두께
+                    ),
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(3),
+                    child: Row(
+                      children: [
+                        Image.asset(
+                          AppIcons.tagIcon,
+                          width: 9,
+                          height: 9,
+                        ),
+                        SizedBox(width: 3),
+                        Text(
+                          recruit!.creatorCampus,
+                          style: AppTextsTheme.main()
+                              .gfCaption5
+                              .copyWith(
+                            color: AppColorsTheme().gfGray800Color,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                SizedBox(width: 5),
+                if (recruit!.remainTime <= 30)
+                  Container(
+                    decoration: BoxDecoration(
+                      color: AppColorsTheme()
+                          .gfWarningYellowBackGroundColor,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(3.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Image.asset(
+                            AppIcons.alertCircle,
+                            width: 9,
+                            height: 9,
+                          ),
+                          SizedBox(width: 3),
+                          Text(
+                            "곧 사라져요!",
+                            style: AppTextsTheme.main()
+                                .gfCaption5
+                                .copyWith(
+                              color: AppColorsTheme()
+                                  .gfWarningYellowColor,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                Spacer(),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Image.asset(
+                      AppIcons.clockGreen,
+                      width: 12,
+                      height: 12,
+                    ),
+                    SizedBox(width: 3),
+                    Text(
+                      '${recruit!.remainTime.toString()} min',
+                      style: AppTextsTheme.main().gfCaption2Light.copyWith(
+                        color: AppColorsTheme().gfMainColor,
+                      ),
+                    ),
+                  ],
+                ),
+                SizedBox(width: 5),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Image.asset(
+                      AppIcons.userGreen,
+                      width: 12,
+                      height: 12,
+                    ),
+                    SizedBox(width: 1),
+                    Text(
+                      '${recruit!.currentParticipants.length.toString()} / ${recruit!.maxParticipants.toString()}',
+                      style: AppTextsTheme.main().gfCaption2Light.copyWith(
+                        color: AppColorsTheme().gfMainColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ) ,
           ],
         ),
       ),

--- a/lib/src/components/greenfield_edit_section.dart
+++ b/lib/src/components/greenfield_edit_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:green_field/src/views/recruitment/picker/recruit_picker_modal.dart';
 import 'dart:io';
 import 'package:image_picker/image_picker.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
@@ -7,6 +8,8 @@ import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
 import 'package:green_field/src/enums/feature_type.dart';
 import '../enums/recruit_setting_type.dart';
+import '../views/recruitment/recruit_setting_section.dart';
+import 'greenfield_campus_picker.dart';
 
 class GreenFieldEditSection extends StatefulWidget {
   final FeatureType type;
@@ -181,91 +184,6 @@ class GreenFieldEditSectionState extends State<GreenFieldEditSection> {
             ),
             SizedBox(height: 30),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class RecruitSettingSection extends StatefulWidget {
-  const RecruitSettingSection({super.key});
-
-  @override
-  RecruitSettingSectionState createState() => RecruitSettingSectionState();
-}
-
-class RecruitSettingSectionState extends State<RecruitSettingSection> {
-  RecruitSettingType? selectedType;
-
-  void _selectType(RecruitSettingType type) {
-    setState(() {
-      selectedType = type;
-    });
-    print("선택된 타입: $selectedType");
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        _recruitSettingBox(
-          icon: CupertinoIcons.time,
-          text: '120분 후 자동삭제',
-          type: RecruitSettingType.autoDeleteTime,
-        ),
-        SizedBox(width: 14),
-        _recruitSettingBox(
-          icon: CupertinoIcons.person,
-          text: '현재 인원수 1명',
-          type: RecruitSettingType.currentPerson,
-        ),
-        SizedBox(width: 14),
-        _recruitSettingBox(
-          icon: CupertinoIcons.person_2_fill,
-          text: '최대 인원수 4명',
-          type: RecruitSettingType.maxPerson,
-        ),
-      ],
-    );
-  }
-
-  Widget _recruitSettingBox({required IconData icon, required String text, required RecruitSettingType type}) {
-    bool isSelected = selectedType == type;
-
-    return Expanded(
-      child: GestureDetector(
-        onTap: () => _selectType(type),
-        child: Container(
-          decoration: BoxDecoration(
-            color: isSelected ? AppColorsTheme().gfMainColor : AppColorsTheme().gfBackGroundColor,
-            borderRadius: BorderRadius.circular(8),
-            boxShadow: [
-              if (!isSelected)
-                BoxShadow(
-                  color: Colors.black.withOpacity(0.25),
-                  spreadRadius: 0,
-                  blurRadius: 4,
-                  offset: Offset(0, 4),
-                ),
-            ],
-          ),
-          height: 70,
-          child: Padding(
-            padding: const EdgeInsets.only(left: 7.0, top: 9),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(icon, size: 32, color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor),
-                SizedBox(height: 5),
-                Text(
-                  text,
-                  style: AppTextsTheme.main().gfBody5.copyWith(
-                    color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor
-                  ),
-                ),
-              ],
-            ),
-          ),
         ),
       ),
     );

--- a/lib/src/components/greenfield_recruit_list.dart
+++ b/lib/src/components/greenfield_recruit_list.dart
@@ -6,14 +6,19 @@ import '../design_system/app_colors.dart';
 
 class GreenFieldRecruitList extends StatelessWidget {
   final Recruit recruits;
+  final VoidCallback onTap;
 
-  const GreenFieldRecruitList({super.key, required this.recruits});
+  const GreenFieldRecruitList({
+    super.key,
+    required this.recruits,
+    required this.onTap
+  });
 
   @override
   Widget build(BuildContext context) {
     return CupertinoButton(
       padding: EdgeInsets.zero,
-      onPressed: () {},
+      onPressed: onTap,
       child: Column(
         children: [
           SizedBox(height: 18),
@@ -46,16 +51,6 @@ class GreenFieldRecruitList extends StatelessWidget {
                             color: AppColorsTheme().gfBlackColor,
                           ),
                     ),
-                    SizedBox(height: 20),
-                    if (recruits.images != null &&
-                        recruits.images!.isNotEmpty) // null 체크 및 비어있지 않은지 확인
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: Image.network(
-                          recruits.images![0], // 첫 번째 이미지만 사용
-                          fit: BoxFit.contain,
-                        ),
-                      ),
                     SizedBox(height: 20),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.start,
@@ -171,7 +166,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                             SizedBox(width: 3),
                             Text(
                               '${recruits.remainTime.toString()} min',
-                              style: AppTextsTheme.main().gfCaption2.copyWith(
+                              style: AppTextsTheme.main().gfCaption2Light.copyWith(
                                     color: AppColorsTheme().gfMainColor,
                                   ),
                             ),
@@ -189,7 +184,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                             SizedBox(width: 1),
                             Text(
                               '${recruits.currentParticipants.length.toString()} / ${recruits.maxParticipants.toString()}',
-                              style: AppTextsTheme.main().gfCaption2.copyWith(
+                              style: AppTextsTheme.main().gfCaption2Light.copyWith(
                                     color: AppColorsTheme().gfMainColor,
                                   ),
                             ),

--- a/lib/src/views/main_view.dart
+++ b/lib/src/views/main_view.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:green_field/src/views/recruitment/picker/recruit_picker_modal.dart';
+import 'package:green_field/src/views/recruitment/recruitment_view.dart';
 import '../components/greenfield_tab_bar.dart';
 import 'board/board_view.dart';
 import 'home/home_view.dart';
@@ -12,8 +14,9 @@ class _MainViewState extends State<MainView> {
   int _selectedIndex = 0;
 
   final List<Widget> _views = [
-    HomeView(),   // First tab view
-    BoardView(),  // Second tab view
+    HomeView(),
+    RecruitView(),
+    BoardView(),
   ];
 
   void _onItemTapped(int index) {

--- a/lib/src/views/recruitment/picker/recruit_picker_modal.dart
+++ b/lib/src/views/recruitment/picker/recruit_picker_modal.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/design_system/app_texts.dart';
+import 'package:green_field/src/enums/recruit_setting_type.dart';
+import '../../../design_system/app_colors.dart';
+
+class RecruitPickerModal extends StatefulWidget {
+  final RecruitSettingType type; // Type of picker (timer or people)
+
+  const RecruitPickerModal({super.key, required this.type});
+
+  @override
+  _RecruitPickerModalState createState() => _RecruitPickerModalState();
+}
+
+class _RecruitPickerModalState extends State<RecruitPickerModal> {
+  String timeString = "30";
+  int currentSelectedCount = 1;
+  int maxSeletedCOunt = 2;
+
+  final List<String> time = List.generate(10, (index) => ((index + 3) * 10).toString());
+  final List<int> currentPeopleCount = List.generate(3, (index) => index + 1);
+  final List<int> maxPeopleCount = List.generate(4, (index) => index + 1);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SizedBox(
+            height: 280,
+            child:
+                _buildPicker(), // Call the method to build the appropriate picker
+          ),
+          Text(
+            widget.type == RecruitSettingType.autoDeleteTime
+                ? '$timeString 분'
+                : '$currentSelectedCount 명', // 선택된 값 표시
+            style: AppTextsTheme.main().gfCaption2.copyWith(
+                  color: AppColorsTheme().gfBlackColor,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPicker() {
+    switch (widget.type) {
+      case RecruitSettingType.autoDeleteTime:
+        return CupertinoPicker.builder(
+          itemExtent: 50,
+          childCount: time.length,
+          onSelectedItemChanged: (i) {
+            setState(() {
+              timeString = time[i];
+            });
+          },
+          itemBuilder: (context, index) {
+            return Center(
+              child: Text(
+                '${time[index]} 분',
+                style: AppTextsTheme.main().gfHeading1.copyWith(
+                      color: AppColorsTheme().gfBlackColor,
+                    ),
+              ),
+            );
+          },
+        );
+      case RecruitSettingType.currentPerson:
+        return CupertinoPicker.builder(
+          itemExtent: 50,
+          childCount: currentPeopleCount.length,
+          onSelectedItemChanged: (i) {
+            setState(() {
+              currentSelectedCount = currentPeopleCount[i];
+            });
+          },
+          itemBuilder: (context, index) {
+            return Center(
+              child: Text(
+                '${currentPeopleCount[index]} 명',
+                style: AppTextsTheme.main().gfHeading1.copyWith(
+                      color: AppColorsTheme().gfBlackColor,
+                    ),
+              ),
+            );
+          },
+        );
+      case RecruitSettingType.maxPerson:
+        return CupertinoPicker.builder(
+          itemExtent: 50,
+          childCount: maxPeopleCount.length,
+          onSelectedItemChanged: (i) {
+            setState(() {
+              maxSeletedCOunt = maxPeopleCount[i];
+            });
+          },
+          itemBuilder: (context, index) {
+            return Center(
+              child: Text(
+                '${maxPeopleCount[index]} 명',
+                style: AppTextsTheme.main().gfHeading1.copyWith(
+                      color: AppColorsTheme().gfBlackColor,
+                    ),
+              ),
+            );
+          },
+        );
+      default:
+        return Container();
+    }
+  }
+}

--- a/lib/src/views/recruitment/picker/recruit_picker_modal.dart
+++ b/lib/src/views/recruitment/picker/recruit_picker_modal.dart
@@ -16,32 +16,18 @@ class RecruitPickerModal extends StatefulWidget {
 class _RecruitPickerModalState extends State<RecruitPickerModal> {
   String timeString = "30";
   int currentSelectedCount = 1;
-  int maxSeletedCOunt = 2;
+  int maxSelectedCount = 2;
 
   final List<String> time = List.generate(10, (index) => ((index + 3) * 10).toString());
   final List<int> currentPeopleCount = List.generate(3, (index) => index + 1);
-  final List<int> maxPeopleCount = List.generate(4, (index) => index + 1);
+  final List<int> maxPeopleCount = List.generate(3, (index) => index + 2);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          SizedBox(
-            height: 280,
-            child:
-                _buildPicker(), // Call the method to build the appropriate picker
-          ),
-          Text(
-            widget.type == RecruitSettingType.autoDeleteTime
-                ? '$timeString 분'
-                : '$currentSelectedCount 명', // 선택된 값 표시
-            style: AppTextsTheme.main().gfCaption2.copyWith(
-                  color: AppColorsTheme().gfBlackColor,
-                ),
-          ),
-        ],
+      body: SizedBox(
+        height: 280,
+        child: _buildPicker(),
       ),
     );
   }
@@ -54,7 +40,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
           childCount: time.length,
           onSelectedItemChanged: (i) {
             setState(() {
-              timeString = time[i];
+              timeString = time[i]; // Update selected time
             });
           },
           itemBuilder: (context, index) {
@@ -75,6 +61,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
           onSelectedItemChanged: (i) {
             setState(() {
               currentSelectedCount = currentPeopleCount[i];
+              maxSelectedCount = currentSelectedCount + 1;
             });
           },
           itemBuilder: (context, index) {
@@ -94,7 +81,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
           childCount: maxPeopleCount.length,
           onSelectedItemChanged: (i) {
             setState(() {
-              maxSeletedCOunt = maxPeopleCount[i];
+              maxSelectedCount = maxPeopleCount[i];
             });
           },
           itemBuilder: (context, index) {

--- a/lib/src/views/recruitment/recruit_edit_view.dart
+++ b/lib/src/views/recruitment/recruit_edit_view.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/components/greenfield_app_bar.dart';
+import 'package:green_field/src/components/greenfield_edit_section.dart'; // Assuming you have a GreenFieldEditSection
+import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/model/recruit.dart';
+
+import '../../design_system/app_texts.dart'; // Assuming you have a Recruit model
+
+class RecruitEditView extends StatefulWidget {
+  const RecruitEditView({super.key});
+
+  @override
+  _RecruitEditViewState createState() => _RecruitEditViewState();
+}
+
+class _RecruitEditViewState extends State<RecruitEditView> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColorsTheme().gfWhiteColor,
+      appBar: GreenFieldAppBar(
+        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        title: "모집글 쓰기",
+        leadingIcon: Icon(
+          CupertinoIcons.xmark,
+          color: AppColorsTheme().gfGray400Color,
+        ),
+        leadingAction: () {
+          Navigator.pop(context);
+        },
+        actions: [
+          CupertinoButton(
+            onPressed: () {
+              print("글쓰기 버튼 클릭");
+            },
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [Color(0xFF308F5B), Color(0xFF666666)],
+                  begin: Alignment.centerLeft,
+                  end: Alignment.centerRight,
+                ),
+                borderRadius: BorderRadius.circular(30),
+              ),
+              height: 30,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 10,vertical: 2),
+                child: Text(
+                  '완료',
+                  style: AppTextsTheme.main().gfCaption2.copyWith(
+                    color: AppColorsTheme().gfWhiteColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: GreenFieldEditSection(
+        type:
+            FeatureType.recruit, // Pass the recruit object to the edit section
+      ),
+    );
+  }
+}

--- a/lib/src/views/recruitment/recruit_setting_section.dart
+++ b/lib/src/views/recruitment/recruit_setting_section.dart
@@ -66,7 +66,11 @@ class RecruitSettingSectionState extends State<RecruitSettingSection> {
                 child: RecruitPickerModal(type: selectedType!),
               );
             },
-          );
+          ).whenComplete(() {
+            setState(() {
+              selectedType = null;
+            });
+          });
         },
         child: Container(
           decoration: BoxDecoration(

--- a/lib/src/views/recruitment/recruit_setting_section.dart
+++ b/lib/src/views/recruitment/recruit_setting_section.dart
@@ -1,0 +1,106 @@
+
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/views/recruitment/picker/recruit_picker_modal.dart';
+
+import '../../design_system/app_colors.dart';
+import '../../design_system/app_texts.dart';
+import '../../enums/recruit_setting_type.dart';
+
+class RecruitSettingSection extends StatefulWidget {
+  const RecruitSettingSection({super.key});
+
+  @override
+  RecruitSettingSectionState createState() => RecruitSettingSectionState();
+}
+
+class RecruitSettingSectionState extends State<RecruitSettingSection> {
+  RecruitSettingType? selectedType;
+
+  void _selectType(RecruitSettingType type) {
+    setState(() {
+      selectedType = type;
+    });
+    print("선택된 타입: $selectedType");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _recruitSettingBox(
+          icon: CupertinoIcons.time,
+          text: '120분 후 자동삭제',
+          type: RecruitSettingType.autoDeleteTime,
+        ),
+        SizedBox(width: 14),
+        _recruitSettingBox(
+          icon: CupertinoIcons.person,
+          text: '현재 인원수 1명',
+          type: RecruitSettingType.currentPerson,
+        ),
+        SizedBox(width: 14),
+        _recruitSettingBox(
+          icon: CupertinoIcons.person_2_fill,
+          text: '최대 인원수 4명',
+          type: RecruitSettingType.maxPerson,
+        ),
+      ],
+    );
+  }
+
+  Widget _recruitSettingBox({required IconData icon, required String text, required RecruitSettingType type}) {
+    bool isSelected = selectedType == type;
+
+    return Expanded(
+      child: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+          _selectType(type);
+          showModalBottomSheet(
+            context: context,
+            builder: (BuildContext context) {
+              return Container(
+                height: 300, // 원하는 높이 설정
+                child: RecruitPickerModal(type: selectedType!),
+              );
+            },
+          );
+        },
+        child: Container(
+          decoration: BoxDecoration(
+            color: isSelected ? AppColorsTheme().gfMainColor : AppColorsTheme().gfBackGroundColor,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              if (!isSelected)
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.25),
+                  spreadRadius: 0,
+                  blurRadius: 4,
+                  offset: Offset(0, 4),
+                ),
+            ],
+          ),
+          height: 70,
+          child: Padding(
+            padding: const EdgeInsets.only(left: 7.0, top: 9),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(icon, size: 32, color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor),
+                SizedBox(height: 5),
+                Text(
+                  text,
+                  style: AppTextsTheme.main().gfBody5.copyWith(
+                      color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/views/recruitment/recruitment_detail_view.dart
+++ b/lib/src/views/recruitment/recruitment_detail_view.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/components/greenfield_app_bar.dart';
+import 'package:green_field/src/components/greenfield_confirm_button.dart';
+import 'package:green_field/src/components/greenfield_content_widget.dart';
+import 'package:green_field/src/components/greenfield_user_info_widget.dart';
+import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/enums/feature_type.dart';
+
+import '../../model/recruit.dart'; // Assuming you have a Recruit model
+
+class RecruitDetailView extends StatefulWidget {
+  final Recruit recruit; // Recruit object to display details
+
+  const RecruitDetailView({super.key, required this.recruit});
+
+  @override
+  _RecruitDetailViewState createState() => _RecruitDetailViewState();
+}
+
+class _RecruitDetailViewState extends State<RecruitDetailView> {
+  @override
+  Widget build(BuildContext context) {
+    final recruit = widget.recruit;
+
+    return Scaffold(
+      backgroundColor: AppColorsTheme().gfWhiteColor,
+      appBar: GreenFieldAppBar(
+        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        title: "모집",
+        leadingIcon: Icon(
+          CupertinoIcons.xmark,
+          color: AppColorsTheme().gfGray400Color,
+        ),
+        leadingAction: (){
+          Navigator.pop(context);
+        },
+      ),
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 16.0),
+                      child: GreenfieldUserInfoWidget(
+                        featureType: FeatureType.recruit,
+                        campus: recruit.creatorCampus,
+                        createTimeText: '${recruit.createdAt.year}-${recruit.createdAt.month}-${recruit.createdAt.day}',
+                      ),
+                    ),
+                    GreenFieldContentWidget(
+                      featureType: FeatureType.recruit,
+                      title: recruit.title,
+                      bodyText: recruit.body,
+                      imageAssets: recruit.images != null && recruit.images!.isNotEmpty ? recruit.images! : [],
+                      recruit: recruit,
+                      commentCount: 0,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+              child: GreenFieldConfirmButton(
+                text: recruit.isEntryAvailable ? "채팅으로 이야기 해보기" : "채팅방 입장 불가",
+                isAble: recruit.isEntryAvailable,
+                textColor: recruit.isEntryAvailable ? AppColorsTheme().gfMainColor : AppColorsTheme().gfWarningColor,
+                backGroundColor: recruit.isEntryAvailable ? AppColorsTheme().gfMainBackGroundColor : AppColorsTheme().gfWarningBackGroundColor,
+                onPressed: () {
+                  print("눌림");
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/views/recruitment/recruitment_view.dart
+++ b/lib/src/views/recruitment/recruitment_view.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/components/greenfield_app_bar.dart';
+import 'package:green_field/src/components/greenfield_recruit_list.dart'; // Import your GreenFieldRecruitList
+import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/views/recruitment/recruit_edit_view.dart';
+import 'package:green_field/src/views/recruitment/recruitment_detail_view.dart';
+
+import '../../model/recruit.dart'; // Assuming you have a Recruit model
+
+class RecruitView extends StatefulWidget {
+  const RecruitView({super.key});
+
+  @override
+  _RecruitViewState createState() => _RecruitViewState();
+}
+
+class _RecruitViewState extends State<RecruitView> {
+  final List<Recruit> recruits = [
+    Recruit(
+      id: '1',
+      creatorId: 'user_001',
+      remainTime: 60, // Remaining time in minutes (1 hour)
+      currentParticipants: ['user_002', 'user_003'],
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 A',
+      isEntryAvailable: true,
+      isTimeExpired: false,
+      title: '여름 인턴 모집',
+      body: '여름 인턴을 모집합니다. 많은 지원 바랍니다.',
+      images: [
+        'https://images.dog.ceo/breeds/pitbull/dog-3981033_1280.jpg',
+      ],
+      createdAt: DateTime.now().subtract(Duration(days: 1)),
+    ),
+    Recruit(
+      id: '2',
+      creatorId: 'user_002',
+      remainTime: 120, // Remaining time in minutes (2 hours)
+      currentParticipants: [],
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 B',
+      isEntryAvailable: true,
+      isTimeExpired: false,
+      title: '동아리 회원 모집',
+      body: '우리 동아리에 가입하세요!',
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 2)),
+    ),
+    Recruit(
+      id: '3',
+      creatorId: 'user_003',
+      remainTime: 30, // Remaining time in minutes (30 minutes)
+      currentParticipants: ['user_004'], // Minimum 1 participant
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 C',
+      isEntryAvailable: true,
+      isTimeExpired: true, // Time expired because remainTime is less than 30 minutes
+      title: '여름 캠프 참가자 모집',
+      body: '여름 캠프에 참여할 학생을 모집합니다!',
+      images: [],
+      createdAt: DateTime.now().subtract(Duration(days: 1)),
+    ),
+    Recruit(
+      id: '4',
+      creatorId: 'user_004',
+      remainTime: 90, // Remaining time in minutes (1 hour 30 minutes)
+      currentParticipants: ['user_005', 'user_006'], // 2 participants
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 D',
+      isEntryAvailable: true,
+      isTimeExpired: false, // Time not expired
+      title: '프로젝트 팀원 모집',
+      body: '프로젝트 팀원을 모집합니다. 많은 지원 바랍니다.',
+      images: [
+        'https://images.dog.ceo/breeds/pitbull/dog-3981033_1280.jpg',
+      ],
+      createdAt: DateTime.now().subtract(Duration(days: 2)),
+    ),
+    Recruit(
+      id: '5',
+      creatorId: 'user_005',
+      remainTime: 40, // Remaining time in minutes
+      currentParticipants: ['user_007', 'user_008', 'user_009'], // 3 participants
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 E',
+      isEntryAvailable: false, // Current participants equal to max participants
+      isTimeExpired: false, // Time not expired
+      title: '여름 방학 프로그램 모집',
+      body: '여름 방학 프로그램에 참여할 학생을 모집합니다.',
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 3)),
+    ),
+    Recruit(
+      id: '6',
+      creatorId: 'user_006',
+      remainTime: 60, // Remaining time in minutes
+      currentParticipants: ['user_010', 'user_011', 'user_012', 'user_013'], // 4 participants
+      maxParticipants: 4,
+      creatorCampus: '캠퍼스 F',
+      isEntryAvailable: false, // Current participants equal to max participants
+      isTimeExpired: false, // Time not expired
+      title: '여름 캠프 팀원 모집',
+      body: '여름 캠프에 참여할 팀원을 모집합니다.',
+      images: null,
+      createdAt: DateTime.now().subtract(Duration(days: 4)),
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColorsTheme().gfBackGroundColor,
+      appBar: GreenFieldAppBar(
+        backgGroundColor: AppColorsTheme().gfBackGroundColor,
+        title: "모집",
+        leadingIcon: SizedBox(),
+        actions: [
+          CupertinoButton(
+              child: Icon(
+                CupertinoIcons.square_pencil,
+                size: 24,
+                color: AppColorsTheme().gfGray400Color,
+              ),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  PageRouteBuilder(
+                    pageBuilder: (context, animation, secondaryAnimation) => RecruitEditView(),
+                    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                      const begin = Offset(0.0, 1.0);
+                      const end = Offset.zero;
+                      const curve = Curves.easeInOut;
+
+                      var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+                      var offsetAnimation = animation.drive(tween);
+
+                      return SlideTransition(
+                        position: offsetAnimation,
+                        child: child,
+                      );
+                    },
+                  ),
+                );
+              },
+          ),
+        ],
+      ),
+      body: ListView.builder(
+        itemCount: recruits.length,
+        itemBuilder: (context, index) {
+          final recruit = recruits[index];
+          return GreenFieldRecruitList(
+            recruits: recruit,
+            onTap: () {
+              Navigator.push(
+                context,
+                PageRouteBuilder(
+                  pageBuilder: (context, animation, secondaryAnimation) => RecruitDetailView(recruit: recruit),
+                  transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                    const begin = Offset(0.0, 1.0);
+                    const end = Offset.zero;
+                    const curve = Curves.easeInOut;
+
+                    var tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+                    var offsetAnimation = animation.drive(tween);
+
+                    return SlideTransition(
+                      position: offsetAnimation,
+                      child: child,
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
## **RecruitView**
`RecruitView`는 모집 공고 목록을 표시하는 Scaffold입니다. 여러 개의 `Recruit` 객체를 받아 리스트 형태로 표시하며, 각 모집 공고 항목을 클릭하면 해당 모집 공고의 세부 정보를 보여주는 화면으로 이동합니다.

### 주요 속성
- **`recruits`**: `List<Recruit>` - 모집 공고 정보를 담고 있는 `Recruit` 객체의 리스트.

### 주요 기능
- **모집 공고 목록 표시**: `ListView.builder`를 사용하여 모집 공고 목록을 동적으로 생성하고 표시합니다.
- **상세보기 네비게이션**: 각 모집 공고 항목을 클릭하면 `RecruitDetailView`로 이동하여 해당 모집 공고의 세부 정보를 보여줍니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 모집 공고 목록의 상태를 관리할 수 있습니다.

### UI 구성 요소
- **AppBar**: [`GreenFieldAppBar`](https://github.com/bulmang/green_field/pull/4#issue-2626048285)를 사용하여 상단에 제목과 글쓰기 버튼을 포함한 앱 바를 설정합니다.
- **모집 공고 항목**: 각 모집 공고는 [`GreenFieldRecruitList`](https://github.com/bulmang/green_field/pull/5#issue-2628689957) 컴포넌트를 통해 표시되며, 제목, 내용, 날짜, 캠퍼스, 이미지 URL, 좋아요 수 등의 정보를 전달합니다.

---

## **RecruitDetailView**
`RecruitDetailView`는 선택된 모집 공고의 세부 정보를 표시하는 Scaffold입니다. 특정 `Recruit` 객체를 받아 해당 모집 공고의 제목, 내용, 작성자 정보 및 이미지를 보여줍니다.

### 주요 속성
- **`recruit`**: `Recruit` - 모집 공고의 세부 정보를 담고 있는 `Recruit` 객체.

### 주요 기능
- **모집 공고 세부 정보 표시**: 선택된 모집 공고의 제목, 내용, 작성자 정보 및 이미지를 표시합니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 모집 공고의 상태를 관리할 수 있습니다.

### UI 구성 요소
- **AppBar**: [`GreenFieldAppBar`](https://github.com/bulmang/green_field/pull/4#issue-2626048285)를 사용하여 상단에 제목과 뒤로 가기 버튼을 포함한 앱 바를 설정합니다.
- **작성자 정보**: `GreenfieldUserInfoWidget`을 사용하여 모집 공고의 작성자 정보와 작성 날짜를 표시합니다.
- **내용 표시**: [`GreenFieldContentWidget`](https://github.com/bulmang/green_field/pull/5#issue-2628689957)을 사용하여 모집 공고의 제목, 내용, 이미지, 좋아요 수 등을 표시합니다.
- **참여 가능 버튼**: 모집 공고의 참여 가능 여부에 따라 버튼을 표시하며, 사용자가 채팅으로 이야기할 수 있는 기능을 제공합니다.
---
## **RecruitEditView**
`RecruitEditView`는 모집 공고를 작성하거나 수정하는 화면입니다. 사용자가 모집 공고의 제목, 내용, 이미지 등을 입력할 수 있는 UI를 제공합니다.

### 주요 속성
- **`recruit`**: `Recruit` - 수정할 모집 공고의 세부 정보를 담고 있는 `Recruit` 객체.

### 주요 기능
- **모집 공고 작성 및 수정**: 사용자가 모집 공고의 세부 정보를 입력하고 수정할 수 있습니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 입력된 내용을 관리할 수 있습니다.

### UI 구성 요소
- **AppBar**: [`GreenFieldAppBar`](https://github.com/bulmang/green_field/pull/4#issue-2626048285)를 사용하여 상단에 제목과 뒤로 가기 버튼을 포함한 앱 바를 설정합니다.
- **편집 섹션**: [`GreenFieldEditSection`](https://github.com/bulmang/green_field/pull/5#issue-2628689957)을 사용하여 모집 공고의 제목, 내용, 이미지 등을 입력할 수 있는 UI를 제공합니다.
- **완료 버튼**: 상단 오른쪽에 위치한 '완료' 버튼을 클릭하면 입력된 내용을 처리하는 기능을 수행합니다.
---
## **RecruitSettingSection**
`RecruitSettingSection`은 모집 공고의 설정을 선택할 수 있는 UI 섹션입니다. 사용자가 자동 삭제 시간, 현재 인원수, 최대 인원수와 같은 설정을 선택할 수 있도록 구성되어 있습니다.

### 주요 속성
- **`selectedType`**: `RecruitSettingType?` - 현재 선택된 설정 유형을 저장합니다.

### 주요 기능
- **설정 선택**: 사용자가 각 설정 박스를 클릭하면 해당 설정 유형이 선택되고, 관련된 Picker가 모달로 표시됩니다.
- **상태 관리**: `StatefulWidget`으로 구현되어 있어, 선택된 설정 유형의 상태를 관리할 수 있습니다.

### UI 구성 요소
- **설정 박스**: 각 설정 항목은 `_recruitSettingBox` 메서드를 통해 생성되며, 아이콘과 텍스트를 포함합니다.
- **모달 표시**: 사용자가 설정 박스를 클릭하면 `showModalBottomSheet`를 사용하여 관련된 Picker를 표시합니다.

---

## **RecruitPickerModal**
`RecruitPickerModal`은 모집 공고 설정을 선택할 수 있는 Picker를 표시하는 모달입니다. 사용자가 자동 삭제 시간이나 인원수를 선택할 수 있도록 구성되어 있습니다.

### 주요 속성
- **`type`**: `RecruitSettingType` - 현재 표시되는 Picker의 유형을 정의합니다.

### 주요 기능
- **시간 또는 인원수 선택**: 사용자가 Picker에서 시간을 선택하거나 인원수를 선택할 수 있습니다.
- **상태 관리**: 선택된 값에 따라 UI가 업데이트됩니다.

### UI 구성 요소
- **CupertinoPicker**: `CupertinoPicker.builder`를 사용하여 시간 또는 인원수를 선택할 수 있는 Picker를 구현합니다.
- **선택된 값 표시**: 선택된 시간 또는 인원수가 화면에 표시됩니다.

### 예시
- **자동 삭제 시간**: 사용자가 자동 삭제 시간을 선택할 수 있는 Picker.
- **현재 인원수**: 현재 참가자 수를 선택할 수 있는 Picker.
- **최대 인원수**: 최대 참가자 수를 선택할 수 있는 Picker.



### 📱 작업 화면
|화면 이름|스크린샷|
|:--:|:--:|
|Recruit|<img src = "https://github.com/user-attachments/assets/c4ba5ef8-f68f-4b7e-b2f7-ce938550ed09" width ="250">|

### 🗒️ Note (optional)
<br>

<br>

