### PR TITLE
[refactor]: Update theme to use extensions

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:green_field/src/design_system/app_texts.dart';
 import 'package:green_field/src/router/router.dart';
 import 'firebase_options.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
@@ -22,10 +23,12 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       routerConfig: router,
-      theme: ThemeData(
-        primaryColor: AppColorsTheme().gfMainColor,
-        scaffoldBackgroundColor: AppColorsTheme().gfBackGroundColor,
-      ),
+      theme: Theme.of(context).copyWith(
+        extensions: [
+          AppColorsTheme(),
+          AppTextsTheme.main(),
+        ]
+      )
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ class MyApp extends StatelessWidget {
       routerConfig: router,
       theme: Theme.of(context).copyWith(
         extensions: [
-          AppColorsTheme(),
+          AppColorsTheme.main(),
           AppTextsTheme.main(),
         ]
       )

--- a/lib/src/components/greenfield_app_bar.dart
+++ b/lib/src/components/greenfield_app_bar.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import '../design_system/app_colors.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import '../design_system/app_texts.dart';
 
 class GreenFieldAppBar extends StatelessWidget implements PreferredSizeWidget {
@@ -55,7 +55,7 @@ class GreenFieldAppBar extends StatelessWidget implements PreferredSizeWidget {
         title: Text(
           title,
           style: AppTextsTheme.main().gfHeading2.copyWith(
-              color: AppColorsTheme().gfBlackColor
+              color: Theme.of(context).appColors.gfBlackColor
           ),
         ),
         actions: actions,

--- a/lib/src/components/greenfield_campus_picker.dart
+++ b/lib/src/components/greenfield_campus_picker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:wheel_picker/wheel_picker.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
@@ -71,7 +72,7 @@ class _GreenFieldCampusPickerState extends State<GreenFieldCampusPicker> {
         style: wheelStyle.copyWith(
           itemExtent: 23.0,
         ),
-        selectedIndexColor: AppColorsTheme().gfMainColor,
+        selectedIndexColor: Theme.of(context).appColors.gfMainColor,
         onIndexChanged: (index) {
           setState(() {
             selectedCampus = campuses[index];
@@ -117,11 +118,11 @@ class _GreenFieldCampusPickerState extends State<GreenFieldCampusPicker> {
               color: Colors.transparent,
               border: Border(
                 top: BorderSide(
-                  color: AppColorsTheme().gfGray400Color,
+                  color: Theme.of(context).appColors.gfGray400Color,
                   width: 1.0,
                 ),
                 bottom: BorderSide(
-                  color: AppColorsTheme().gfGray400Color,
+                  color: Theme.of(context).appColors.gfGray400Color,
                   width: 1.0,
                 ),
               ),
@@ -131,7 +132,7 @@ class _GreenFieldCampusPickerState extends State<GreenFieldCampusPicker> {
             padding: EdgeInsets.only(right: screenWidth * 0.25),
             child: Text(
               '캠퍼스',
-              style: AppTextsTheme.main().gfHeading3.copyWith(color: AppColorsTheme().gfMainColor),
+              style: AppTextsTheme.main().gfHeading3.copyWith(color: Theme.of(context).appColors.gfMainColor),
             ),
           ),
         ],

--- a/lib/src/components/greenfield_comment_widget.dart
+++ b/lib/src/components/greenfield_comment_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../design_system/app_texts.dart';
 
@@ -23,7 +24,7 @@ class GreenFieldCommentWidget extends StatelessWidget {
       children: [
         Divider(
           height: 1,
-          color: AppColorsTheme().gfGray300Color,
+          color: Theme.of(context).appColors.gfGray300Color,
         ),
         SizedBox(height: 8),
         Container(
@@ -42,14 +43,14 @@ class GreenFieldCommentWidget extends StatelessWidget {
                         Text(
                           campus,
                           style: AppTextsTheme.main().gfBody5.copyWith(
-                            color: AppColorsTheme().gfBlackColor,
+                            color: Theme.of(context).appColors.gfBlackColor,
                           ),
                         ),
                         SizedBox(height: 2),
                         Text(
                           '${dateTime.month}/${dateTime.day} ${dateTime.hour}:${dateTime.minute.toString().padLeft(2, '0')}',
                           style: AppTextsTheme.main().gfCaption5.copyWith(
-                            color: AppColorsTheme().gfGray400Color,
+                            color: Theme.of(context).appColors.gfGray400Color,
                           ),
                         ),
                       ],
@@ -61,7 +62,7 @@ class GreenFieldCommentWidget extends StatelessWidget {
               Text(
                   comment.length > 300 ? '${comment.substring(0, 300)}...' : comment,
                   style: AppTextsTheme.main().gfBody5.copyWith(
-                    color: AppColorsTheme().gfBlackColor,
+                    color: Theme.of(context).appColors.gfBlackColor,
                   )
               ),
             ],

--- a/lib/src/components/greenfield_content_widget.dart
+++ b/lib/src/components/greenfield_content_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/model/recruit.dart';
 
 import '../design_system/app_colors.dart';
@@ -37,14 +38,14 @@ class GreenFieldContentWidget extends StatelessWidget {
             Text(
               title,
               style: AppTextsTheme.main().gfHeading1.copyWith(
-                color: AppColorsTheme().gfBlackColor,
+                color: Theme.of(context).appColors.gfBlackColor,
               ),
             ),
             SizedBox(height: 17),
             Text(
               bodyText,
               style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                color: AppColorsTheme().gfBlackColor,
+                color: Theme.of(context).appColors.gfBlackColor,
               ),
             ),
             SizedBox(height: 17),
@@ -106,7 +107,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                     Text(
                       likes.toString(),
                       style: AppTextsTheme.main().gfCaption5.copyWith(
-                        color: AppColorsTheme().gfMainColor,
+                        color: Theme.of(context).appColors.gfMainColor,
                       ),
                     ),
                   ],
@@ -124,7 +125,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                     Text(
                       commentCount.toString(),
                       style: AppTextsTheme.main().gfCaption5.copyWith(
-                        color: AppColorsTheme().gfMainColor,
+                        color: Theme.of(context).appColors.gfMainColor,
                       ),
                     ),
                   ],
@@ -136,7 +137,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                 Container(
                   decoration: BoxDecoration(
                     border: Border.all(
-                      color: AppColorsTheme().gfGray800Color, // 테두리 색상
+                      color: Theme.of(context).appColors.gfGray800Color, // 테두리 색상
                       width: 1, // 테두리 두께
                     ),
                     borderRadius: BorderRadius.circular(3),
@@ -156,7 +157,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                           style: AppTextsTheme.main()
                               .gfCaption5
                               .copyWith(
-                            color: AppColorsTheme().gfGray800Color,
+                            color: Theme.of(context).appColors.gfGray800Color,
                           ),
                         ),
                       ],
@@ -167,7 +168,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                 if (recruit!.remainTime <= 30)
                   Container(
                     decoration: BoxDecoration(
-                      color: AppColorsTheme()
+                      color: Theme.of(context).appColors
                           .gfWarningYellowBackGroundColor,
                       borderRadius: BorderRadius.circular(8),
                     ),
@@ -187,7 +188,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                             style: AppTextsTheme.main()
                                 .gfCaption5
                                 .copyWith(
-                              color: AppColorsTheme()
+                              color: Theme.of(context).appColors
                                   .gfWarningYellowColor,
                             ),
                           ),
@@ -208,7 +209,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                     Text(
                       '${recruit!.remainTime.toString()} min',
                       style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                        color: AppColorsTheme().gfMainColor,
+                        color: Theme.of(context).appColors.gfMainColor,
                       ),
                     ),
                   ],
@@ -226,7 +227,7 @@ class GreenFieldContentWidget extends StatelessWidget {
                     Text(
                       '${recruit!.currentParticipants.length.toString()} / ${recruit!.maxParticipants.toString()}',
                       style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                        color: AppColorsTheme().gfMainColor,
+                        color: Theme.of(context).appColors.gfMainColor,
                       ),
                     ),
                   ],

--- a/lib/src/components/greenfield_edit_section.dart
+++ b/lib/src/components/greenfield_edit_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/views/recruitment/picker/recruit_picker_modal.dart';
 import 'dart:io';
 import 'package:image_picker/image_picker.dart';
@@ -60,16 +61,16 @@ class GreenFieldEditSectionState extends State<GreenFieldEditSection> {
                       maxLength: 50,
                       maxLines: 1,
                       style: AppTextsTheme.main().gfHeading1.copyWith(
-                        color: AppColorsTheme().gfBlackColor,
+                        color: Theme.of(context).appColors.gfBlackColor,
                       ),
                       decoration: InputDecoration(
                         hintText: '제목',
-                        hintStyle: TextStyle(color: AppColorsTheme().gfGray400Color),
+                        hintStyle: TextStyle(color: Theme.of(context).appColors.gfGray400Color),
                         focusedBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: AppColorsTheme().gfMainColor, width: 2),
+                          borderSide: BorderSide(color: Theme.of(context).appColors.gfMainColor, width: 2),
                         ),
                         enabledBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: AppColorsTheme().gfGray400Color, width: 1),
+                          borderSide: BorderSide(color: Theme.of(context).appColors.gfGray400Color, width: 1),
                         ),
                       ),
                     ),
@@ -79,16 +80,16 @@ class GreenFieldEditSectionState extends State<GreenFieldEditSection> {
                       minLines: 8,
                       maxLines: null,
                       style: AppTextsTheme.main().gfBody1.copyWith(
-                        color: AppColorsTheme().gfBlackColor,
+                        color: Theme.of(context).appColors.gfBlackColor,
                       ),
                       decoration: InputDecoration(
                         hintText: '내용을 입력하세요.',
-                        hintStyle: TextStyle(color: AppColorsTheme().gfGray400Color),
+                        hintStyle: TextStyle(color: Theme.of(context).appColors.gfGray400Color),
                         focusedBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: AppColorsTheme().gfMainColor, width: 2),
+                          borderSide: BorderSide(color: Theme.of(context).appColors.gfMainColor, width: 2),
                         ),
                         enabledBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(color: AppColorsTheme().gfGray400Color, width: 1),
+                          borderSide: BorderSide(color: Theme.of(context).appColors.gfGray400Color, width: 1),
                         ),
                       ),
                     ),
@@ -125,7 +126,7 @@ class GreenFieldEditSectionState extends State<GreenFieldEditSection> {
                                       width: 30,
                                       height: 30,
                                       decoration: BoxDecoration(
-                                        color: AppColorsTheme().gfWarningColor,
+                                        color: Theme.of(context).appColors.gfWarningColor,
                                         borderRadius: BorderRadius.circular(8),
                                       ),
                                       child: Icon(
@@ -164,7 +165,7 @@ class GreenFieldEditSectionState extends State<GreenFieldEditSection> {
                         '- 음란물 및 성적 수치심 유발 행위 금지\n'
                         '- 스포일러, 공포, 속임수, 놀라게 하는 행위 금지',
                         style: AppTextsTheme.main().gfCaption4.copyWith(
-                          color: AppColorsTheme().gfGray400Color,
+                          color: Theme.of(context).appColors.gfGray400Color,
                         ),
                       ),
                   ],

--- a/lib/src/components/greenfield_list.dart
+++ b/lib/src/components/greenfield_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import '../design_system/app_colors.dart';
 
 class GreenFieldList extends StatelessWidget {
@@ -51,7 +52,7 @@ class GreenFieldList extends StatelessWidget {
                             title,
                             maxLines: 1,
                             style: AppTextsTheme.main().gfHeading3.copyWith(
-                              color: AppColorsTheme().gfBlackColor,
+                              color: Theme.of(context).appColors.gfBlackColor,
                             ),
                           ),
                           Text(
@@ -59,7 +60,7 @@ class GreenFieldList extends StatelessWidget {
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                             style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                              color: AppColorsTheme().gfBlackColor,
+                              color: Theme.of(context).appColors.gfBlackColor,
                             ),
                           ),
                           SizedBox(height: 6),
@@ -69,14 +70,14 @@ class GreenFieldList extends StatelessWidget {
                               Text(
                                 date,
                                 style: AppTextsTheme.main().gfCaption5.copyWith(
-                                  color: AppColorsTheme().gfGray800Color,
+                                  color: Theme.of(context).appColors.gfGray800Color,
                                 ),
                               ),
                               SizedBox(width: 5),
                               Text(
                                 campus,
                                 style: AppTextsTheme.main().gfCaption5.copyWith(
-                                  color: AppColorsTheme().gfMainColor,
+                                  color: Theme.of(context).appColors.gfMainColor,
                                 ),
                               ),
                               SizedBox(width: 5),
@@ -92,7 +93,7 @@ class GreenFieldList extends StatelessWidget {
                                   Text(
                                     likes.toString(),
                                     style: AppTextsTheme.main().gfCaption5.copyWith(
-                                      color: AppColorsTheme().gfMainColor,
+                                      color: Theme.of(context).appColors.gfMainColor,
                                     ),
                                   ),
                                 ],
@@ -110,7 +111,7 @@ class GreenFieldList extends StatelessWidget {
                                   Text(
                                     commentCount.toString(),
                                     style: AppTextsTheme.main().gfCaption5.copyWith(
-                                      color: AppColorsTheme().gfMainColor,
+                                      color: Theme.of(context).appColors.gfMainColor,
                                     ),
                                   ),
                                 ],
@@ -137,7 +138,7 @@ class GreenFieldList extends StatelessWidget {
             SizedBox(height: 6),
             Divider(
               height: 2,
-              color: AppColorsTheme().gfGray300Color,
+              color: Theme.of(context).appColors.gfGray300Color,
             )
           ],
         ),

--- a/lib/src/components/greenfield_recruit_list.dart
+++ b/lib/src/components/greenfield_recruit_list.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/model/recruit.dart';
 import '../design_system/app_colors.dart';
 
@@ -26,7 +28,7 @@ class GreenFieldRecruitList extends StatelessWidget {
             padding: const EdgeInsets.only(left: 16.0, right: 16.0),
             child: Container(
               decoration: BoxDecoration(
-                color: AppColorsTheme().gfWhiteColor,
+                color: Theme.of(context).appColors.gfWhiteColor,
                 borderRadius: BorderRadius.circular(8.0),
               ),
               child: Padding(
@@ -39,7 +41,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: AppTextsTheme.main().gfTitle1.copyWith(
-                            color: AppColorsTheme().gfBlackColor,
+                            color: Theme.of(context).appColors.gfBlackColor,
                           ),
                     ),
                     SizedBox(height: 5),
@@ -48,7 +50,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: AppTextsTheme.main().gfBody2.copyWith(
-                            color: AppColorsTheme().gfBlackColor,
+                            color: Theme.of(context).appColors.gfBlackColor,
                           ),
                     ),
                     SizedBox(height: 20),
@@ -58,7 +60,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                         Container(
                           decoration: BoxDecoration(
                             border: Border.all(
-                              color: AppColorsTheme().gfGray800Color, // 테두리 색상
+                              color: Theme.of(context).appColors.gfGray800Color, // 테두리 색상
                               width: 1, // 테두리 두께
                             ),
                             borderRadius: BorderRadius.circular(3),
@@ -78,7 +80,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                                   style: AppTextsTheme.main()
                                       .gfCaption5
                                       .copyWith(
-                                        color: AppColorsTheme().gfGray800Color,
+                                        color: Theme.of(context).appColors.gfGray800Color,
                                       ),
                                 ),
                               ],
@@ -89,8 +91,8 @@ class GreenFieldRecruitList extends StatelessWidget {
                         Container(
                           decoration: BoxDecoration(
                             color: recruits.isEntryAvailable
-                                ? AppColorsTheme().gfMainBackGroundColor
-                                : AppColorsTheme().gfWarningBackGroundColor,
+                                ? Theme.of(context).appColors.gfMainBackGroundColor
+                                : Theme.of(context).appColors.gfWarningBackGroundColor,
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Padding(
@@ -114,8 +116,8 @@ class GreenFieldRecruitList extends StatelessWidget {
                                       .gfCaption5
                                       .copyWith(
                                         color: recruits.isEntryAvailable
-                                            ? AppColorsTheme().gfMainColor
-                                            : AppColorsTheme().gfWarningColor,
+                                            ? Theme.of(context).appColors.gfMainColor
+                                            : Theme.of(context).appColors.gfWarningColor,
                                       ),
                                 ),
                               ],
@@ -126,7 +128,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                         if (recruits.isTimeExpired)
                           Container(
                             decoration: BoxDecoration(
-                              color: AppColorsTheme()
+                              color: Theme.of(context).appColors
                                   .gfWarningYellowBackGroundColor,
                               borderRadius: BorderRadius.circular(8),
                             ),
@@ -146,7 +148,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                                     style: AppTextsTheme.main()
                                         .gfCaption5
                                         .copyWith(
-                                          color: AppColorsTheme()
+                                          color: Theme.of(context).appColors
                                               .gfWarningYellowColor,
                                         ),
                                   ),
@@ -167,7 +169,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                             Text(
                               '${recruits.remainTime.toString()} min',
                               style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                                    color: AppColorsTheme().gfMainColor,
+                                    color: Theme.of(context).appColors.gfMainColor,
                                   ),
                             ),
                           ],
@@ -185,7 +187,7 @@ class GreenFieldRecruitList extends StatelessWidget {
                             Text(
                               '${recruits.currentParticipants.length.toString()} / ${recruits.maxParticipants.toString()}',
                               style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                                    color: AppColorsTheme().gfMainColor,
+                                    color: Theme.of(context).appColors.gfMainColor,
                                   ),
                             ),
                           ],

--- a/lib/src/components/greenfield_tab_bar.dart
+++ b/lib/src/components/greenfield_tab_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../design_system/app_colors.dart';
 import '../design_system/app_texts.dart';
@@ -26,14 +27,14 @@ class GreenFieldTabBar extends StatelessWidget {
                   CupertinoIcons.home,
                   size: 24,
                   color: navigationShell.currentIndex == 0
-                      ? AppColorsTheme().gfMainColor
+                      ? Theme.of(context).appColors.gfMainColor
                       : Colors.grey,
                 ),
                 Text(
                   '홈',
                   style: AppTextsTheme.main().gfBody5.copyWith(
                     color: navigationShell.currentIndex == 0
-                        ? AppColorsTheme().gfMainColor
+                        ? Theme.of(context).appColors.gfMainColor
                         : Colors.grey,
                   ),
                 ),
@@ -49,14 +50,14 @@ class GreenFieldTabBar extends StatelessWidget {
                 CupertinoIcons.person_2,
                 size: 24,
                 color: navigationShell.currentIndex == 1
-                    ? AppColorsTheme().gfMainColor
+                    ? Theme.of(context).appColors.gfMainColor
                     : Colors.grey,
               ),
               Text(
                 '모집',
                 style: AppTextsTheme.main().gfBody5.copyWith(
                   color: navigationShell.currentIndex == 1
-                      ? AppColorsTheme().gfMainColor
+                      ? Theme.of(context).appColors.gfMainColor
                       : Colors.grey,
                 ),
               ),
@@ -71,14 +72,14 @@ class GreenFieldTabBar extends StatelessWidget {
                 CupertinoIcons.chat_bubble_text,
                 size: 24,
                 color: navigationShell.currentIndex == 2
-                    ? AppColorsTheme().gfMainColor
+                    ? Theme.of(context).appColors.gfMainColor
                     : Colors.grey,
               ),
               Text(
                 '게시판',
                 style: AppTextsTheme.main().gfBody5.copyWith(
                   color: navigationShell.currentIndex == 2
-                      ? AppColorsTheme().gfMainColor
+                      ? Theme.of(context).appColors.gfMainColor
                       : Colors.grey,
                 ),
               ),
@@ -93,13 +94,13 @@ class GreenFieldTabBar extends StatelessWidget {
                 CupertinoIcons.info,
                 size: 24,
                 color: navigationShell.currentIndex == 3
-                    ? AppColorsTheme().gfMainColor
+                    ? Theme.of(context).appColors.gfMainColor
                     : Colors.grey,
               ),
               Text('캠퍼스',
                   style: AppTextsTheme.main().gfBody5.copyWith(
                     color: navigationShell.currentIndex == 3
-                        ? AppColorsTheme().gfMainColor
+                        ? Theme.of(context).appColors.gfMainColor
                         : Colors.grey,
                   )),
             ],

--- a/lib/src/components/greenfield_text_field.dart
+++ b/lib/src/components/greenfield_text_field.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import '../design_system/app_texts.dart';
 
 class GreenFieldTextField extends StatefulWidget {
@@ -24,13 +25,13 @@ class GreenFieldTextFieldState extends State<GreenFieldTextField> {
       children: [
         Container(
           height: 90,
-          color: AppColorsTheme().gfBackGroundColor,
+          color: Theme.of(context).appColors.gfBackGroundColor,
         ),
         Padding(
           padding: const EdgeInsets.only(top: 12, left: 16.0, right: 16.0),
           child: Container(
             decoration: BoxDecoration(
-              color: AppColorsTheme().gfMainBackGroundColor,
+              color: Theme.of(context).appColors.gfMainBackGroundColor,
               borderRadius: BorderRadius.circular(8),
             ),
             child: TextField(
@@ -56,12 +57,12 @@ class GreenFieldTextFieldState extends State<GreenFieldTextField> {
                       }
                     },
                     color: Colors.transparent,
-                    child: Icon(CupertinoIcons.paperplane_fill, color: AppColorsTheme().gfMainColor),
+                    child: Icon(CupertinoIcons.paperplane_fill, color: Theme.of(context).appColors.gfMainColor),
                   ),
                 ),
               ),
               style: AppTextsTheme.main().gfTitle2.copyWith(
-                color: _isEmpty ? AppColorsTheme().gfGray400Color : AppColorsTheme().gfBlackColor,
+                color: _isEmpty ? Theme.of(context).appColors.gfGray400Color : Theme.of(context).appColors.gfBlackColor,
               ),
             ),
           ),

--- a/lib/src/components/greenfield_user_info_widget.dart
+++ b/lib/src/components/greenfield_user_info_widget.dart
@@ -46,13 +46,13 @@ class GreenfieldUserInfoWidget extends StatelessWidget {
                   Text(
                     featureType  == FeatureType.notice ? campus :'익명($campus)',
                     style: AppTextsTheme.main().gfHeading3.copyWith(
-                      color: featureType  == FeatureType.notice ? AppColorsTheme().gfMainColor : AppColorsTheme().gfGray800Color,
+                      color: featureType  == FeatureType.notice ? AppColorsTheme.main().gfMainColor : AppColorsTheme.main().gfGray800Color,
                     ),
                   ),
                   Text(
                     createTimeText,
                     style: AppTextsTheme.main().gfBody5.copyWith(
-                      color: AppColorsTheme().gfGray400Color,
+                      color: AppColorsTheme.main().gfGray400Color,
                     ),
                   ),
                 ],

--- a/lib/src/design_system/app_colors.dart
+++ b/lib/src/design_system/app_colors.dart
@@ -34,13 +34,13 @@ class AppColorsTheme extends ThemeExtension<AppColorsTheme> {
     required this.gfBlackColor,
   });
 
-  factory AppColorsTheme() {
-    return AppColorsTheme._internal(
+  factory AppColorsTheme.main() {
+    return const AppColorsTheme._internal(
       gfMainColor: const Color(0xFF02542D),
-      gfMainBackGroundColor: const Color(0xFF02542D).withOpacity(0.1),
-      gfWarningBackGroundColor: const Color(0xFFFF6A69).withOpacity(0.1),
+      gfMainBackGroundColor: const Color(0xFFE2EAE8),
+      gfWarningBackGroundColor: const Color(0xFFFBECEE),
       gfWarningYellowColor: const Color(0xFFFFC35A),
-      gfWarningYellowBackGroundColor: const Color(0xFFFFC35A).withOpacity(0.1),
+      gfWarningYellowBackGroundColor: const Color(0xFFFBF2E4),
       gfWarningColor: const Color(0xFFFF6A69),
       gfBlueColor: const Color(0xFF007AFF),
       gfWhiteColor: const Color(0xFFFBFBFD),
@@ -55,7 +55,7 @@ class AppColorsTheme extends ThemeExtension<AppColorsTheme> {
 
   @override
   AppColorsTheme copyWith() {
-    return AppColorsTheme();
+    return AppColorsTheme.main();
   }
 
   @override

--- a/lib/src/model/post.dart
+++ b/lib/src/model/post.dart
@@ -21,7 +21,7 @@ class Post {
     required this.like,
     images,
     comment,
-  }): images = images ?? [], comment = comment ?? [];
+  }): images = List.from(images ?? []), comment = List.from(comment ?? []);
 
   Map<String, dynamic> toMap() {
     return {

--- a/lib/src/views/campus/campus_operating_section.dart
+++ b/lib/src/views/campus/campus_operating_section.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../../design_system/app_colors.dart';
 import '../../design_system/app_icons.dart';
 import '../../design_system/app_texts.dart';
 import '../../model/campus.dart';
@@ -25,7 +26,7 @@ class CampusOperatingSection extends StatelessWidget {
                 child: Text(
                   hour,
                   style: AppTextsTheme.main().gfBody1.copyWith(
-                    color: AppColorsTheme().gfBlackColor,
+                    color: Theme.of(context).appColors.gfBlackColor,
                   ),
                 ),
               );
@@ -42,7 +43,7 @@ class CampusOperatingSection extends StatelessWidget {
               Text(
                 CampusExample().gwanack.contactNumber,
                 style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                  color: AppColorsTheme().gfBlackColor,
+                  color: Theme.of(context).appColors.gfBlackColor,
                 ),
               ),
               SizedBox(width: 8),
@@ -63,7 +64,7 @@ class CampusOperatingSection extends StatelessWidget {
                 child: Text(
                   "전화하기",
                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                    color: AppColorsTheme().gfMainColor,
+                    color: Theme.of(context).appColors.gfMainColor,
                   ),
                 ),
               ),

--- a/lib/src/views/campus/campus_view.dart
+++ b/lib/src/views/campus/campus_view.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/views/campus/camus_floor_section.dart';
 import 'package:green_field/src/views/campus/camus_map_section.dart';
 import 'package:green_field/src/views/campus/campus_operating_section.dart';
 
-import '../../design_system/app_colors.dart';
 import '../../design_system/app_texts.dart';
 
 class CampusView extends StatefulWidget {
@@ -128,7 +128,7 @@ class _CampusViewState extends State<CampusView> {
             child: Container(
               decoration: BoxDecoration(
                 border: Border.all(
-                  color: AppColorsTheme().gfMainColor, // 테두리 색상
+                  color: Theme.of(context).appColors.gfMainColor, // 테두리 색상
                   width: 1, // 테두리 두께
                 ),
                 borderRadius: BorderRadius.circular(15),
@@ -144,14 +144,14 @@ class _CampusViewState extends State<CampusView> {
                       child: Text(
                         '관악 캠퍼스',
                         style: AppTextsTheme.main().gfHeading3.copyWith(
-                              color: AppColorsTheme().gfMainColor,
+                              color: Theme.of(context).appColors.gfMainColor,
                             ),
                       ),
                     ),
                     SizedBox(width: 3), // Space between icon and text
                     Icon(
                       CupertinoIcons.chevron_down,
-                      color: AppColorsTheme().gfMainColor,
+                      color: Theme.of(context).appColors.gfMainColor,
                       size: 18,
                     ),
                   ],
@@ -163,8 +163,8 @@ class _CampusViewState extends State<CampusView> {
         ],
       ),
       bottom: TabBar(
-        indicatorColor: AppColorsTheme().gfMainColor,
-        labelColor: AppColorsTheme().gfMainColor,
+        indicatorColor: Theme.of(context).appColors.gfMainColor,
+        labelColor: Theme.of(context).appColors.gfMainColor,
         splashFactory: NoSplash.splashFactory,
         onTap: (int index) => scrollToIndex(index),
         tabs: List.generate(3, (int index) {
@@ -173,13 +173,13 @@ class _CampusViewState extends State<CampusView> {
             child: Text(
               titles[index],
               style: AppTextsTheme.main().gfTitle1.copyWith(
-                    color: AppColorsTheme().gfMainColor,
+                    color: Theme.of(context).appColors.gfMainColor,
                   ),
             ),
           );
         }),
       ),
-      backgroundColor: AppColorsTheme().gfBackGroundColor,
+      backgroundColor: Theme.of(context).appColors.gfBackGroundColor,
     );
   }
 
@@ -197,7 +197,7 @@ class _CampusViewState extends State<CampusView> {
               Text(
                 title,
                 style: AppTextsTheme.main().gfTitle1.copyWith(
-                      color: AppColorsTheme().gfBlackColor,
+                      color: Theme.of(context).appColors.gfBlackColor,
                     ),
               ),
             ],

--- a/lib/src/views/campus/camus_floor_section.dart
+++ b/lib/src/views/campus/camus_floor_section.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../design_system/app_colors.dart';
@@ -25,7 +27,7 @@ class CampusFloorSection extends StatelessWidget {
               Text(
                 floor,
                 style: AppTextsTheme.main().gfBody2.copyWith(
-                  color: AppColorsTheme().gfBlackColor,
+                  color: Theme.of(context).appColors.gfBlackColor,
                 ),
               ),
               SizedBox(height: 4), // 텍스트와 이미지 사이의 간격

--- a/lib/src/views/campus/camus_map_section.dart
+++ b/lib/src/views/campus/camus_map_section.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../../design_system/app_colors.dart';
 import '../../design_system/app_icons.dart';
 import '../../design_system/app_texts.dart';
 import '../../model/campus.dart';
@@ -51,14 +52,14 @@ class CampusMapSection extends StatelessWidget {
               Text(
                 CampusExample().gwanack.address['CampusAddress']!,
                 style: AppTextsTheme.main().gfCaption2Light.copyWith(
-                  color: AppColorsTheme().gfBlackColor,
+                  color: Theme.of(context).appColors.gfBlackColor,
                 ),
               ),
               SizedBox(width: 8),
               Text(
                 "검색하기",
                 style: AppTextsTheme.main().gfCaption2.copyWith(
-                  color: AppColorsTheme().gfMainColor,
+                  color: Theme.of(context).appColors.gfMainColor,
                 ),
               ),
             ],

--- a/lib/src/views/home/home_view.dart
+++ b/lib/src/views/home/home_view.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/views/home/sections/expiring_soon_recruit_section.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/views/home/sections/notice_carousel_section.dart';
-import '../../design_system/app_colors.dart';
 import '../../design_system/app_texts.dart';
 import '../../viewmodels/user_view_model.dart';
 import 'sections/external_link_section.dart';
@@ -50,14 +50,14 @@ class _HomeViewState extends State<HomeView> {
                             Text(
                               '익명(${userVM.user.campus})',
                               style: AppTextsTheme.main().gfTitle1.copyWith(
-                                    color: AppColorsTheme().gfBlackColor,
+                                    color: Theme.of(context).appColors.gfBlackColor,
                                   ),
                             ),
                             SizedBox(height: 3),
                             Text(
                               userVM.user.course,
                               style: AppTextsTheme.main().gfBody5.copyWith(
-                                    color: AppColorsTheme().gfGray400Color,
+                                    color: Theme.of(context).appColors.gfGray400Color,
                                   ),
                             ),
                           ],
@@ -73,7 +73,7 @@ class _HomeViewState extends State<HomeView> {
                         Text(
                           '${userVM.user.campus} 공지사항',
                           style: AppTextsTheme.main().gfTitle2.copyWith(
-                                color: AppColorsTheme().gfBlackColor,
+                                color: Theme.of(context).appColors.gfBlackColor,
                               ),
                         ),
                         SizedBox(height: 5),
@@ -93,7 +93,7 @@ class _HomeViewState extends State<HomeView> {
                         Text(
                           'HOT 게시판',
                           style: AppTextsTheme.main().gfTitle2.copyWith(
-                            color: AppColorsTheme().gfBlackColor,
+                            color: Theme.of(context).appColors.gfBlackColor,
                           ),
                         ),
                         SizedBox(height: 5),
@@ -111,7 +111,7 @@ class _HomeViewState extends State<HomeView> {
                 child: Text(
                   '곧 사라지는 실시간 모집글',
                   style: AppTextsTheme.main().gfTitle2.copyWith(
-                    color: AppColorsTheme().gfBlackColor,
+                    color: Theme.of(context).appColors.gfBlackColor,
                   ),
                 ),
               ),

--- a/lib/src/views/home/sections/expiring_soon_recruit_section.dart
+++ b/lib/src/views/home/sections/expiring_soon_recruit_section.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/viewmodels/recruit_view_model.dart';
-import '../../../design_system/app_colors.dart';
 import '../../../design_system/app_texts.dart';
-import '../../../model/recruit.dart';
 
 class ExpiringSoonRecruitSection extends StatelessWidget {
 
@@ -28,7 +28,7 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                 padding: EdgeInsets.symmetric(horizontal: 12),
                 width: MediaQuery.of(context).size.width / 1.3,
                 decoration: BoxDecoration(
-                  color: AppColorsTheme().gfMainColor.withOpacity(0.6 - (index * 0.1)),
+                  color: Theme.of(context).appColors.gfMainColor.withOpacity(0.6 - (index * 0.1)),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: CupertinoButton(
@@ -46,7 +46,7 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: AppTextsTheme.main().gfTitle2.copyWith(
-                            color: AppColorsTheme().gfWhiteColor,
+                            color: Theme.of(context).appColors.gfWhiteColor,
                           ),
                         ),
                         SizedBox(height: 5),
@@ -56,7 +56,7 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                             child: Text(
                               recruit.body,
                               style: AppTextsTheme.main().gfCaption2.copyWith(
-                                color: AppColorsTheme().gfWhiteColor,
+                                color: Theme.of(context).appColors.gfWhiteColor,
                               ),
                             ),
                           ),
@@ -70,14 +70,14 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                                 Text(
                                   '참여하기',
                                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                                    color: AppColorsTheme().gfWhiteColor,
+                                    color: Theme.of(context).appColors.gfWhiteColor,
                                   ),
                                 ),
                                 SizedBox(width: 3),
                                 Icon(
                                   CupertinoIcons.chevron_right,
                                   size:12,
-                                  color: AppColorsTheme().gfWhiteColor,
+                                  color: Theme.of(context).appColors.gfWhiteColor,
                                 ),
                               ],
                             ),
@@ -94,7 +94,7 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                                 Text(
                                   '${recruit.remainTime.toString()} min',
                                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                                    color: AppColorsTheme().gfWhiteColor,
+                                    color: Theme.of(context).appColors.gfWhiteColor,
                                   ),
                                 ),
                               ],
@@ -112,7 +112,7 @@ class ExpiringSoonRecruitSection extends StatelessWidget {
                                 Text(
                                   '${recruit.currentParticipants.length.toString()} / ${recruit.maxParticipants.toString()}',
                                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                                    color: AppColorsTheme().gfWhiteColor,
+                                    color: Theme.of(context).appColors.gfWhiteColor,
                                   ),
                                 ),
                               ],

--- a/lib/src/views/home/sections/external_link_section.dart
+++ b/lib/src/views/home/sections/external_link_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../design_system/app_colors.dart';
@@ -58,7 +59,7 @@ Widget iconText(String imagePath, String label, VoidCallback onPressed) {
         Text(
           label,
           style: AppTextsTheme.main().gfCaption2.copyWith(
-            color: AppColorsTheme().gfBlackColor,
+            color: AppColorsTheme.main().gfBlackColor,
           ),
         ),
       ],

--- a/lib/src/views/home/sections/notice_carousel_section.dart
+++ b/lib/src/views/home/sections/notice_carousel_section.dart
@@ -1,8 +1,9 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
-import '../../../design_system/app_colors.dart';
 import '../../../design_system/app_texts.dart';
 import '../../../viewmodels/notice_view_model.dart';
 
@@ -30,7 +31,7 @@ class NoticeCarouselSectionState extends State<NoticeCarouselSection> {
                 return ClipRRect(
                   borderRadius: BorderRadius.circular(10),
                   child: Container(
-                    color: AppColorsTheme().gfWhiteColor,
+                    color: Theme.of(context).appColors.gfWhiteColor,
                     child: CupertinoButton(
                       padding: EdgeInsets.zero,
                       onPressed: () {
@@ -50,7 +51,7 @@ class NoticeCarouselSectionState extends State<NoticeCarouselSection> {
                                     maxLines: 1,
                                     overflow: TextOverflow.ellipsis,
                                     style: AppTextsTheme.main().gfTitle1.copyWith(
-                                      color: AppColorsTheme().gfBlackColor,
+                                      color: Theme.of(context).appColors.gfBlackColor,
                                     ),
                                   ),
                                   Text(
@@ -58,7 +59,7 @@ class NoticeCarouselSectionState extends State<NoticeCarouselSection> {
                                     maxLines: 2,
                                     overflow: TextOverflow.ellipsis,
                                     style: AppTextsTheme.main().gfBody4.copyWith(
-                                      color: AppColorsTheme().gfBlackColor,
+                                      color: Theme.of(context).appColors.gfBlackColor,
                                     ),
                                   ),
                                 ],
@@ -110,8 +111,8 @@ class NoticeCarouselSectionState extends State<NoticeCarouselSection> {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: _currentIndex == index
-                    ? AppColorsTheme().gfMainColor // Active color
-                    : AppColorsTheme().gfGray300Color, // Inactive color
+                    ? Theme.of(context).appColors.gfMainColor // Active color
+                    : Theme.of(context).appColors.gfGray300Color, // Inactive color
               ),
             );
           }).toList(),

--- a/lib/src/views/home/sections/top_liked_posts_section.dart
+++ b/lib/src/views/home/sections/top_liked_posts_section.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:intl/intl.dart';
 
 import 'package:green_field/src/design_system/app_icons.dart';
-import '../../../design_system/app_colors.dart';
 import '../../../design_system/app_texts.dart';
 import '../../../model/post.dart';
 import '../../../viewmodels/post_view_model.dart';
@@ -29,9 +29,9 @@ class TopLikedPostsSection extends StatelessWidget {
 
           return Column(
             children: [
-              if (index == 1) Container(height: 1, color: AppColorsTheme().gfGray300Color),
+              if (index == 1) Container(height: 1, color: Theme.of(context).appColors.gfGray300Color),
               Container(
-                color: AppColorsTheme().gfWhiteColor,
+                color: Theme.of(context).appColors.gfWhiteColor,
                 child: CupertinoButton(
                   padding: EdgeInsets.zero,
                   onPressed: () {
@@ -50,7 +50,7 @@ class TopLikedPostsSection extends StatelessWidget {
                                 post.title,
                                 maxLines: 1,
                                 style: AppTextsTheme.main().gfHeading3.copyWith(
-                                  color: AppColorsTheme().gfBlackColor,
+                                  color: Theme.of(context).appColors.gfBlackColor,
                                 ),
                               ),
                               SizedBox(height: 6),
@@ -60,14 +60,14 @@ class TopLikedPostsSection extends StatelessWidget {
                                   Text(
                                     formattedDate,
                                     style: AppTextsTheme.main().gfCaption5.copyWith(
-                                      color: AppColorsTheme().gfGray800Color,
+                                      color: Theme.of(context).appColors.gfGray800Color,
                                     ),
                                   ),
                                   SizedBox(width: 5),
                                   Text(
                                     post.creatorCampus,
                                     style: AppTextsTheme.main().gfCaption5.copyWith(
-                                      color: AppColorsTheme().gfMainColor,
+                                      color: Theme.of(context).appColors.gfMainColor,
                                     ),
                                   ),
                                   Spacer(),
@@ -84,7 +84,7 @@ class TopLikedPostsSection extends StatelessWidget {
                                       Text(
                                         post.like.length.toString(),
                                         style: AppTextsTheme.main().gfCaption5.copyWith(
-                                          color: AppColorsTheme().gfMainColor,
+                                          color: Theme.of(context).appColors.gfMainColor,
                                         ),
                                       ),
                                     ],
@@ -102,7 +102,7 @@ class TopLikedPostsSection extends StatelessWidget {
                                       Text(
                                         '0',
                                         style: AppTextsTheme.main().gfCaption5.copyWith(
-                                          color: AppColorsTheme().gfMainColor,
+                                          color: Theme.of(context).appColors.gfMainColor,
                                         ),
                                       ),
                                     ],
@@ -117,7 +117,7 @@ class TopLikedPostsSection extends StatelessWidget {
                   ),
                 ),
               ),
-              if (index == 1) Container(height: 1, color: AppColorsTheme().gfGray300Color),
+              if (index == 1) Container(height: 1, color: Theme.of(context).appColors.gfGray300Color),
             ],
           );
         }),

--- a/lib/src/views/login/login_view.dart
+++ b/lib/src/views/login/login_view.dart
@@ -5,6 +5,7 @@ import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/design_system/app_icons.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
 import 'package:green_field/src/enums/login_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 class LoginView extends StatelessWidget {
   const LoginView({super.key});
@@ -19,7 +20,7 @@ class LoginView extends StatelessWidget {
             Text('새싹 수강생 커뮤니티, 그린필드',
                 style: AppTextsTheme.main()
                     .gfHeading1
-                    .copyWith(color: AppColorsTheme().gfMainColor)),
+                    .copyWith(color: Theme.of(context).appColors.gfMainColor)),
             Image.asset(
               AppIcons.loginSesac,
               width: 240,
@@ -49,7 +50,7 @@ class LoginView extends StatelessWidget {
                         '로그인 없이 둘러보기',
                         style: AppTextsTheme.main()
                             .gfCaption1
-                            .copyWith(color: AppColorsTheme().gfGray400Color),
+                            .copyWith(color: Theme.of(context).appColors.gfGray400Color),
                       ),
                     ),
                     SizedBox(width: 10),
@@ -60,7 +61,7 @@ class LoginView extends StatelessWidget {
                         child: Text(
                           '문의하기',
                           style: AppTextsTheme.main().gfCaption1.copyWith(
-                              color: AppColorsTheme().gfGray400Color),
+                              color: Theme.of(context).appColors.gfGray400Color),
                         )),
                   ],
                 ),
@@ -88,7 +89,7 @@ Widget signInButton({
           borderRadius: BorderRadius.circular(8),
           color: loginType == LoginType.kakao
               ? const Color(0XFFFEE500)
-              : AppColorsTheme().gfBlackColor,
+              : AppColorsTheme.main().gfBlackColor,
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -112,8 +113,8 @@ Widget signInButton({
                 ,
                 style: AppTextsTheme.main().gfTitle1.copyWith(
                       color: loginType == LoginType.kakao
-                          ? AppColorsTheme().gfBlackColor
-                          : AppColorsTheme().gfWhiteColor,
+                          ? AppColorsTheme.main().gfBlackColor
+                          : AppColorsTheme.main().gfWhiteColor,
                     ),
               ),
             ),

--- a/lib/src/views/login/onboarding_view.dart
+++ b/lib/src/views/login/onboarding_view.dart
@@ -3,6 +3,7 @@ import 'package:green_field/src/components/greenfield_campus_picker.dart';
 import 'package:green_field/src/components/greenfield_confirm_button.dart';
 import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 class OnboardingView extends StatelessWidget {
   const OnboardingView({super.key});
@@ -23,7 +24,7 @@ class OnboardingView extends StatelessWidget {
                     Text(
                       '안녕하세요\n캠퍼스와 강의를 알려주세요.',
                       style: AppTextsTheme.main().gfHeading1.copyWith(
-                        color: AppColorsTheme().gfMainColor,
+                        color: Theme.of(context).appColors.gfMainColor,
                       ),
                     ),
                     SizedBox(height: 40),
@@ -33,7 +34,7 @@ class OnboardingView extends StatelessWidget {
                         Text(
                           "캠퍼스위치",
                           style: AppTextsTheme.main().gfTitle3.copyWith(
-                            color: AppColorsTheme().gfGray800Color,
+                            color: Theme.of(context).appColors.gfGray800Color,
                           ),
                         ),
                         const SizedBox(height: 8),
@@ -42,7 +43,7 @@ class OnboardingView extends StatelessWidget {
                         Text(
                           "학습 및 학습 완료 강좌",
                           style: AppTextsTheme.main().gfTitle3.copyWith(
-                            color: AppColorsTheme().gfGray800Color,
+                            color: Theme.of(context).appColors.gfGray800Color,
                           ),
                         ),
                         const SizedBox(height: 8),
@@ -58,8 +59,8 @@ class OnboardingView extends StatelessWidget {
               child: GreenFieldConfirmButton(
                 text: "시작하기",
                 isAble: true,
-                textColor: AppColorsTheme().gfWhiteColor,
-                backGroundColor: AppColorsTheme().gfMainColor,
+                textColor: Theme.of(context).appColors.gfWhiteColor,
+                backGroundColor: Theme.of(context).appColors.gfMainColor,
                 onPressed: () {
                   print("시작하기 버튼 클릭됨.");
                 },
@@ -80,7 +81,7 @@ Widget customTextField({
 
   return Container(
     decoration: BoxDecoration(
-      color: AppColorsTheme().gfGray100Color,
+      color: AppColorsTheme.main().gfGray100Color,
       borderRadius: BorderRadius.circular(8),
     ),
     child: TextField(
@@ -88,12 +89,12 @@ Widget customTextField({
       onChanged: onAction,
       decoration: InputDecoration(
         hintText: hintText ?? '학습중이거나 학습완료 강좌 입력.',
-        hintStyle: TextStyle(color: AppColorsTheme().gfGray400Color),
+        hintStyle: TextStyle(color: AppColorsTheme.main().gfGray400Color),
         border: InputBorder.none,
         contentPadding: EdgeInsets.symmetric(vertical: 12, horizontal: 20),
       ),
       style: AppTextsTheme.main().gfTitle2.copyWith(
-        color: AppColorsTheme().gfBlackColor,
+        color: AppColorsTheme.main().gfBlackColor,
       ),
     ),
   );

--- a/lib/src/views/notice/notice_deatil_view.dart
+++ b/lib/src/views/notice/notice_deatil_view.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_content_widget.dart';
 import 'package:green_field/src/components/greenfield_user_info_widget.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../../model/notice.dart';
 
@@ -23,9 +23,9 @@ class _NoticeDetailViewState extends State<NoticeDetailView> {
     final notice = widget.notice;
 
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: "공지사항",
       ),
       body: SingleChildScrollView(

--- a/lib/src/views/notice/notice_view.dart
+++ b/lib/src/views/notice/notice_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_list.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../../viewmodels/notice_view_model.dart';
 
@@ -19,9 +19,9 @@ class _NoticeViewState extends State<NoticeView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: "공지사항",
       ),
       body: ListView.builder(

--- a/lib/src/views/post/post_detail_view.dart
+++ b/lib/src/views/post/post_detail_view.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_comment_widget.dart';
 import 'package:green_field/src/components/greenfield_content_widget.dart';
 import 'package:green_field/src/components/greenfield_text_field.dart';
 import 'package:green_field/src/components/greenfield_user_info_widget.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/model/post.dart';
-import 'package:green_field/src/router/router.dart';
 
 class PostDetailView extends StatefulWidget {
   final Post post; // Assuming BoardPost is your model
@@ -25,9 +23,9 @@ class _PostDetailViewState extends State<PostDetailView> {
     final post = widget.post;
 
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: _getLimitedTitle(post.title, 20),
       ),
       body: GestureDetector(

--- a/lib/src/views/post/post_edit_view.dart
+++ b/lib/src/views/post/post_edit_view.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_edit_section.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import '../../design_system/app_texts.dart';
 
 class PostEditView extends StatefulWidget {
@@ -18,13 +18,13 @@ class _PostEditViewState extends State<PostEditView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: "모집글 쓰기",
         leadingIcon: Icon(
           CupertinoIcons.xmark,
-          color: AppColorsTheme().gfGray400Color,
+          color: Theme.of(context).appColors.gfGray400Color,
         ),
         leadingAction: () {
           context.pop();
@@ -49,7 +49,7 @@ class _PostEditViewState extends State<PostEditView> {
                 child: Text(
                   '완료',
                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                    color: AppColorsTheme().gfWhiteColor,
+                    color: Theme.of(context).appColors.gfWhiteColor,
                   ),
                 ),
               ),

--- a/lib/src/views/post/post_view.dart
+++ b/lib/src/views/post/post_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_list.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/viewmodels/post_view_model.dart';
 import '../../design_system/app_texts.dart';
 
@@ -27,9 +27,9 @@ class _PostViewState extends State<PostView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfBackGroundColor,
+      backgroundColor: Theme.of(context).appColors.gfBackGroundColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfBackGroundColor,
+        backgGroundColor: Theme.of(context).appColors.gfBackGroundColor,
         title: "게시판",
         leadingIcon: SizedBox(),
         actions: [
@@ -37,7 +37,7 @@ class _PostViewState extends State<PostView> {
               child: Icon(
                 CupertinoIcons.square_pencil,
                 size: 24,
-                color: AppColorsTheme().gfGray400Color,
+                color: Theme.of(context).appColors.gfGray400Color,
               ),
               onPressed: () {
                 context.go('/post/edit');
@@ -95,7 +95,7 @@ class _PostViewState extends State<PostView> {
                     child: Text(
                       '글 쓰기',
                       style: AppTextsTheme.main().gfCaption2.copyWith(
-                            color: AppColorsTheme().gfWhiteColor,
+                            color: Theme.of(context).appColors.gfWhiteColor,
                           ),
                     ),
                   ),

--- a/lib/src/views/recruitment/picker/recruit_picker_modal.dart
+++ b/lib/src/views/recruitment/picker/recruit_picker_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:green_field/src/design_system/app_texts.dart';
 import 'package:green_field/src/enums/recruit_setting_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import '../../../design_system/app_colors.dart';
 
 class RecruitPickerModal extends StatefulWidget {
@@ -48,7 +49,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
               child: Text(
                 '${time[index]} 분',
                 style: AppTextsTheme.main().gfHeading1.copyWith(
-                      color: AppColorsTheme().gfBlackColor,
+                      color: Theme.of(context).appColors.gfBlackColor,
                     ),
               ),
             );
@@ -69,7 +70,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
               child: Text(
                 '${currentPeopleCount[index]} 명',
                 style: AppTextsTheme.main().gfHeading1.copyWith(
-                      color: AppColorsTheme().gfBlackColor,
+                      color: Theme.of(context).appColors.gfBlackColor,
                     ),
               ),
             );
@@ -89,7 +90,7 @@ class _RecruitPickerModalState extends State<RecruitPickerModal> {
               child: Text(
                 '${maxPeopleCount[index]} 명',
                 style: AppTextsTheme.main().gfHeading1.copyWith(
-                      color: AppColorsTheme().gfBlackColor,
+                      color: Theme.of(context).appColors.gfBlackColor,
                     ),
               ),
             );

--- a/lib/src/views/recruitment/recruit_edit_view.dart
+++ b/lib/src/views/recruitment/recruit_edit_view.dart
@@ -3,9 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_edit_section.dart'; // Assuming you have a GreenFieldEditSection
-import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
-import 'package:green_field/src/model/recruit.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../../design_system/app_texts.dart'; // Assuming you have a Recruit model
 
@@ -20,13 +19,13 @@ class _RecruitEditViewState extends State<RecruitEditView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: "모집글 쓰기",
         leadingIcon: Icon(
           CupertinoIcons.xmark,
-          color: AppColorsTheme().gfGray400Color,
+          color: Theme.of(context).appColors.gfGray400Color,
         ),
         leadingAction: () {
           context.pop();
@@ -51,7 +50,7 @@ class _RecruitEditViewState extends State<RecruitEditView> {
                 child: Text(
                   '완료',
                   style: AppTextsTheme.main().gfCaption2.copyWith(
-                    color: AppColorsTheme().gfWhiteColor,
+                    color: Theme.of(context).appColors.gfWhiteColor,
                   ),
                 ),
               ),

--- a/lib/src/views/recruitment/recruit_setting_section.dart
+++ b/lib/src/views/recruitment/recruit_setting_section.dart
@@ -2,9 +2,9 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 import 'package:green_field/src/views/recruitment/picker/recruit_picker_modal.dart';
 
-import '../../design_system/app_colors.dart';
 import '../../design_system/app_texts.dart';
 import '../../enums/recruit_setting_type.dart';
 
@@ -74,7 +74,7 @@ class RecruitSettingSectionState extends State<RecruitSettingSection> {
         },
         child: Container(
           decoration: BoxDecoration(
-            color: isSelected ? AppColorsTheme().gfMainColor : AppColorsTheme().gfBackGroundColor,
+            color: isSelected ? Theme.of(context).appColors.gfMainColor : Theme.of(context).appColors.gfBackGroundColor,
             borderRadius: BorderRadius.circular(8),
             boxShadow: [
               if (!isSelected)
@@ -92,12 +92,12 @@ class RecruitSettingSectionState extends State<RecruitSettingSection> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(icon, size: 32, color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor),
+                Icon(icon, size: 32, color: isSelected ? Theme.of(context).appColors.gfBackGroundColor : Theme.of(context).appColors.gfMainColor),
                 SizedBox(height: 5),
                 Text(
                   text,
                   style: AppTextsTheme.main().gfBody5.copyWith(
-                      color: isSelected ? AppColorsTheme().gfBackGroundColor : AppColorsTheme().gfMainColor
+                      color: isSelected ? Theme.of(context).appColors.gfBackGroundColor : Theme.of(context).appColors.gfMainColor
                   ),
                 ),
               ],

--- a/lib/src/views/recruitment/recruitment_detail_view.dart
+++ b/lib/src/views/recruitment/recruitment_detail_view.dart
@@ -5,8 +5,8 @@ import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_confirm_button.dart';
 import 'package:green_field/src/components/greenfield_content_widget.dart';
 import 'package:green_field/src/components/greenfield_user_info_widget.dart';
-import 'package:green_field/src/design_system/app_colors.dart';
 import 'package:green_field/src/enums/feature_type.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../../model/recruit.dart'; // Assuming you have a Recruit model
 
@@ -25,13 +25,13 @@ class _RecruitDetailViewState extends State<RecruitDetailView> {
     final recruit = widget.recruit;
 
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfWhiteColor,
+      backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfWhiteColor,
+        backgGroundColor: Theme.of(context).appColors.gfWhiteColor,
         title: "모집",
         leadingIcon: Icon(
           CupertinoIcons.xmark,
-          color: AppColorsTheme().gfGray400Color,
+          color: Theme.of(context).appColors.gfGray400Color,
         ),
         leadingAction: (){
           context.pop();
@@ -70,8 +70,8 @@ class _RecruitDetailViewState extends State<RecruitDetailView> {
               child: GreenFieldConfirmButton(
                 text: recruit.isEntryAvailable ? "채팅으로 이야기 해보기" : "채팅방 입장 불가",
                 isAble: recruit.isEntryAvailable,
-                textColor: recruit.isEntryAvailable ? AppColorsTheme().gfMainColor : AppColorsTheme().gfWarningColor,
-                backGroundColor: recruit.isEntryAvailable ? AppColorsTheme().gfMainBackGroundColor : AppColorsTheme().gfWarningBackGroundColor,
+                textColor: recruit.isEntryAvailable ? Theme.of(context).appColors.gfMainColor : Theme.of(context).appColors.gfWarningColor,
+                backGroundColor: recruit.isEntryAvailable ? Theme.of(context).appColors.gfMainBackGroundColor : Theme.of(context).appColors.gfWarningBackGroundColor,
                 onPressed: () {
                   print("눌림");
                 },

--- a/lib/src/views/recruitment/recruitment_view.dart
+++ b/lib/src/views/recruitment/recruitment_view.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/components/greenfield_app_bar.dart';
 import 'package:green_field/src/components/greenfield_recruit_list.dart'; // Import your GreenFieldRecruitList
-import 'package:green_field/src/design_system/app_colors.dart';
-import 'package:green_field/src/views/recruitment/recruit_edit_view.dart';
+import 'package:green_field/src/extensions/theme_data_extension.dart';
 
 import '../../viewmodels/recruit_view_model.dart';
 
@@ -21,9 +20,9 @@ class _RecruitViewState extends State<RecruitView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColorsTheme().gfBackGroundColor,
+      backgroundColor: Theme.of(context).appColors.gfBackGroundColor,
       appBar: GreenFieldAppBar(
-        backgGroundColor: AppColorsTheme().gfBackGroundColor,
+        backgGroundColor: Theme.of(context).appColors.gfBackGroundColor,
         title: "모집",
         leadingIcon: SizedBox(),
         actions: [
@@ -31,7 +30,7 @@ class _RecruitViewState extends State<RecruitView> {
               child: Icon(
                 CupertinoIcons.square_pencil,
                 size: 24,
-                color: AppColorsTheme().gfGray400Color,
+                color: Theme.of(context).appColors.gfGray400Color,
               ),
               onPressed: () {
                 context.go('/recruit/edit');


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
이전 [디자인 시스템 개발 작업](https://github.com/bulmang/green_field/pull/3#issue-2622929479)에서 적용했던 부분 중에 잘못된 부분이 있어 리팩토링 하였습니다. 이전에는 `AppColorsTheme().gfBlackColor`를 사용하여 색을 정해주었는데 이 객체가 같은 주소를 참조하는 객체가 아니 다른 주소를 참조하는 객체를 계속 생성하여 사용했던 문제였습니다.

### 객체를 복사하여 사용
리팩토링 되기 전 코드에서는 AppColorsTheme()를 사용하여 AppColorsTheme()안에 있는 색을 사용했습니다.
HomeView UI와 NoticeView UI가 그려질 때 마다 주소값을 출력해보겠습니다.
```dart
    final appColor = AppColorsTheme();
    final appColor2 = AppColorsTheme();
    print("home appcolor: ${appColor.hashCode}");
    print("home appcolo2r: ${appColor2.hashCode}");

    final appColor = AppColorsTheme();
    final appColor2 = AppColorsTheme();
    print("notice appcolor: ${appColor.hashCode}");
    print("notice appcolo2r: ${appColor2.hashCode}");
```
hashCode는 객체의 내용을 기반으로 생성된 정수 값입니다. 
일반적으로 같은 내용의 객체는 같은 hashCode를 반환합니다.
아래 출력 로그를 보시면 hashCode가 다른 것을 확인할 수 있습니다.
물론 이 객체가 사이즈가 엄청 작은 객체이어 큰 영향을 주지 않지만 좋지 않은 개발입니다.

그림으로 그려보면 View를 그릴때 만약 View 하나를 그릴 때 AppColorsTheme()를 16번 사용하였다고 가정한다면 View가 한 번 그려질때 16개의 객체가 생성되는 것입니다. 그러면 View를 10번 그리면 160개의 객체가 생성됩니다.
그러면 필요하지도 않는 객체를 계속 생성하여 불필요한 메모리 사용을 하고 있는 상황입니다.

|화면 이름|스크린샷|
|:--:|:--:|
|여러객체생성|<img src = "https://github.com/user-attachments/assets/e246aaae-959f-411e-91e2-6e37ae6f3ead" width ="450">|
|현재상황|<img src = "https://github.com/user-attachments/assets/7fb8fb39-3a36-426e-adc3-7170b563beb1" width ="750">|



### 방법 1. const만 사용하여 같은 객체를 참조하자.
출력은 위에 상황과 똑같습니다. 
변경된 코드는 AppColorsTheme의 프로퍼티들을 모두 const로 지정하였습니다.
```dart
class AppColorsTheme {
  final Color gfMainColor = const Color(0xFF02542D); // 02542D
  final Color gfMainBackGroundColor = const Color(0xFFE2EAE8); // 02542D with 10% opacity
  final Color gfWarningBackGroundColor = const Color(0xFFFBECEE); // FF6A69 with 10% opacity
  final Color gfWarningYellowColor = const Color(0xFFFFC35A); // FFC35A
  final Color gfWarningYellowBackGroundColor = const Color(0xFFFBF2E4); // FFC35A with 10% opacity
  final Color gfWarningColor = const Color(0xFFFF6A69); // FF6A69
  final Color gfBlueColor = const Color(0xFF007AFF); // 007AFF
  final Color gfWhiteColor = const Color(0xFFFBFBFD); // FBFDFD
  final Color gfBackGroundColor = const Color(0xFFF4F4F9); // F4F4F9
  final Color gfGray100Color = const Color(0xFFF3F4F6); // F3F4F6
  final Color gfGray300Color = const Color(0xFFDBDEE2); // DBDEE2
  final Color gfGray400Color = const Color(0xFF8B95A1); // 8B95A1
  final Color gfGray800Color = const Color(0xFF535961); // 535961
  final Color gfBlackColor = const Color(0xFF000000); // 000000
  const AppColorsTheme();
}
```
Dart에서는 const로 지정된 값은 컴파일 타임 상수로 간주되며, 동일한 const 인스턴스는 애플리케이션 전체에서 재사용됩니다. 
즉, const로 생성된 객체는 불변(immutable)이며, 메모리에서 동일한 인스턴스를 공유하게 됩니다. 
아래 출력 로그를 보면 모든 같은 hashcode를 가진 것을 볼 수 있습니다.
즉 1000번의 View를 그려도 단 하나의 객체만 생성되고 그 객체를 이용하는 것입니다.

|화면 이름|스크린샷|
|:--:|:--:|
|const|<img src = "https://github.com/user-attachments/assets/d8dadeb3-ea58-4d16-b9c1-4584e0dbc70a" width ="450">|
|현재상황|<img src = "https://github.com/user-attachments/assets/724af762-a0d4-41ea-9dd1-a52a3c87b16c" width ="750">|

이 방법은 간단하고 직관적이지만,, 필요한 로직이 있을때 관리하기가 어렵습니다. 그래서 범용성 부분에서 아쉬운 모습이 있습니다.


### 방법 2. Theme를 이용하자.
Flutter에서는 Theme의 여러 속성에 값을 넣어 사용할 수 있습니다.
그렇다면 Extension을 사용해서 Theme에 제가 사용할 디자인 시스템을 추가하는 것입니다.

ThemeData를 extension 하여 appColors와 appTexts를 사용할 수 있게 합니다.
그리고 MaterialApp에 theme에다가 넣어주어 직접 사용할 수 있도록 합니다. 
아래 코드를 보시면 이해하기 쉽습니다.
```dart
class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return. MaterialApp.router(
      routerConfig: router,
      theme: Theme.of(context).copyWith(
        extensions: [
          AppColorsTheme.main(),
          AppTextsTheme.main(),
        ]
      )
    );
  }
}
```
```dart
extension ThemeDataExtended on ThemeData {
  AppColorsTheme get appColors => extension<AppColorsTheme>()!;
  AppTextsTheme get appTexts => extension<AppTextsTheme>()!;
}
```

이렇게 Theme 설정을 하였다면 Theme.of(context).appColors를 사용하여 색을 지정해주면 됩니다.
Theme.of(context).appColors안에 제가 지정해둔 모든 색이 담겨있기 때문에 편리하게 가져와서 사용하면됩니다.
이렇게 사용하는 방식도 같은 객체를 사용하는 지 확인해보겠습니다.
출력할 코드는 Home과 Recruit에 넣어보겠습니다.
```
    final appColor = Theme.of(context).appColors;
    final appColor2 = Theme.of(context).appColors;
    print("home appcolor: ${appColor.hashCode}");
    print("home appcolo2r: ${appColor2.hashCode}");

    final appColor = Theme.of(context).appColors;
    final appColor2 = Theme.of(context).appColors;
    print("recruit appcolor: ${appColor.hashCode}");
    print("recruit appcolo2r: ${appColor2.hashCode}");
```

|화면 이름|스크린샷|
|:--:|:--:|
|Theme|<img src = "https://github.com/user-attachments/assets/4aefed73-c3d3-49bf-8293-8791e8f9ffa6" width ="450">|
|현재상황|<img src = "https://github.com/user-attachments/assets/d21b4565-0953-4182-847a-5b65417bbf20" width ="750">|


### 결론
이렇게 지금까지 직접 테스트 해보며 같은 인스턴스를 사용하여 효율적인 메모리 사용을 하게 디자인 시스템을 리팩토링 하였습니다.
저는 개발의 편의성을 위해서 Theme를 사용했지만 더 좋은 코드가 있다고 생각합니다.
이렇게 사용하는 것에 대해서 의견 주시면 감사하겠습니다!

추가로 AppTextsTheme.main()도 const Constructor를 따르고 있게 같은 인스턴스를 재사용합니다.

<br>




## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
