### PR TITLE
[feat]: Implement SettingViewModel and add user logout functionality

### DIFF
--- a/lib/src/cores/router/router.g.dart
+++ b/lib/src/cores/router/router.g.dart
@@ -6,7 +6,7 @@ part of 'router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$goRouterHash() => r'7dc35956afd87d272a1163091e68f4ecb15cd594';
+String _$goRouterHash() => r'2e00160c84cb04623f2447fa629ef6f054a5b897';
 
 /// See also [goRouter].
 @ProviderFor(goRouter)

--- a/lib/src/datas/repositories/login_repository.dart
+++ b/lib/src/datas/repositories/login_repository.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:green_field/src/datas/services/firebase_auth_service.dart';
@@ -9,7 +10,7 @@ import '../../cores/error_handler/result.dart';
 class LoginRepository {
   final FirebaseAuthService firebaseAuthService;
 
-  LoginRepository({ required this.firebaseAuthService});
+  LoginRepository({required this.firebaseAuthService});
 
   Future<Result<Token, Exception>> signInWithKakao() async {
     final result = await firebaseAuthService.signInWithKakao();
@@ -34,6 +35,28 @@ class LoginRepository {
         return Failure(exception);
       default:
         throw Exception('Unexpected result type');
+    }
+  }
+
+  Future<Result<void, Exception>> signOut() async {
+    final result = await firebaseAuthService.signOut();
+
+    switch (result) {
+      case Success(value: final value):
+        return Success(value);
+      case Failure(exception: final exception):
+        return Failure(exception);
+    }
+  }
+
+  Future<Result<void, Exception>> deleteUser() async {
+    final result = await firebaseAuthService.deleteUser();
+
+    switch (result) {
+      case Success(value: final v):
+        return Success(v);
+      case Failure(exception: final exception):
+        return Failure(exception);
     }
   }
 }

--- a/lib/src/datas/repositories/login_repository.dart
+++ b/lib/src/datas/repositories/login_repository.dart
@@ -1,10 +1,7 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:green_field/src/datas/services/firebase_auth_service.dart';
-import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:green_field/src/model/token.dart';
-import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart' as kakao;
 import '../../cores/error_handler/result.dart';
 
 class LoginRepository {
@@ -38,27 +35,6 @@ class LoginRepository {
     }
   }
 
-  Future<Result<void, Exception>> signOut() async {
-    final result = await firebaseAuthService.signOut();
-
-    switch (result) {
-      case Success(value: final value):
-        return Success(value);
-      case Failure(exception: final exception):
-        return Failure(exception);
-    }
-  }
-
-  Future<Result<void, Exception>> deleteUser() async {
-    final result = await firebaseAuthService.deleteUser();
-
-    switch (result) {
-      case Success(value: final v):
-        return Success(v);
-      case Failure(exception: final exception):
-        return Failure(exception);
-    }
-  }
 }
 
 final loginRepositoryProvider = Provider<LoginRepository>((ref) {

--- a/lib/src/datas/repositories/login_repository.dart
+++ b/lib/src/datas/repositories/login_repository.dart
@@ -1,4 +1,4 @@
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:green_field/src/datas/services/firebase_auth_service.dart';
 import 'package:green_field/src/model/token.dart';
@@ -35,9 +35,22 @@ class LoginRepository {
     }
   }
 
+  Future<Result<firebase_auth.User, Exception>> signInWithAnonymously() async {
+    final result = await firebaseAuthService.signInAnonymously();
+
+    switch (result) {
+      case Success(value: final v):
+        return Success(v);
+      case Failure(exception: final exception):
+        return Failure(exception);
+      default:
+        throw Exception('Unexpected result type');
+    }
+  }
+
 }
 
 final loginRepositoryProvider = Provider<LoginRepository>((ref) {
-  return LoginRepository(firebaseAuthService: FirebaseAuthService(FirebaseAuth.instance));
+  return LoginRepository(firebaseAuthService: FirebaseAuthService(firebase_auth.FirebaseAuth.instance));
 });
 

--- a/lib/src/datas/repositories/notice_repository.dart
+++ b/lib/src/datas/repositories/notice_repository.dart
@@ -17,7 +17,7 @@ class NoticeRepository {
   NoticeRepository({required this.firebaseStoreService, required this.firebaseStorageService});
 
   /// Notice 리스트 가져오기
-  Future<Result<List<Notice>, Exception>> getNoticeList(User user) async {
+  Future<Result<List<Notice>, Exception>> getNoticeList(User? user) async {
     try {
       final result = await firebaseStoreService.getNoticeList(user);
 

--- a/lib/src/datas/repositories/onboarding_repository.dart
+++ b/lib/src/datas/repositories/onboarding_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:green_field/src/datas/services/firebase_auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import '../../cores/error_handler/result.dart';
+import '../../model/token.dart';
 import '../../model/user.dart' as myUser;
 import '../services/firebase_store_service.dart';
 
@@ -13,9 +14,25 @@ class OnboardingRepository {
   OnboardingRepository({required this.firebaseAuthService, required this.firebaseStoreService});
 
   // Auth User 생성
-  Future<Result<firebase_auth.User, Exception>> createAuthUser(String provider, String idToken, String accessToken) async {
+  Future<Result<firebase_auth.User, Exception>> createAuthUser(String provider, String idToken, String accessToken, String providerUID) async {
     try {
-      final result = await firebaseAuthService.connectFirebaseAuth(provider, idToken, accessToken);
+      final result = await firebaseAuthService.connectFirebaseAuth(provider, idToken, accessToken, providerUID);
+
+      switch (result) {
+        case Success(value: final authUser):
+          return Success(authUser);
+        case Failure(exception: final exception):
+          return Failure(exception);
+      }
+    } on Exception catch (error) {
+      return Failure(error);
+    }
+  }
+
+  // 기존 유저 정보가 있다면 AuthUser 생성
+  Future<Result<void, Exception>> isExistUserCreateAuth(Token token) async {
+    try {
+      final result = await firebaseAuthService.isExistUserConnectFirebaseAuth(token);
 
       switch (result) {
         case Success(value: final authUser):
@@ -45,13 +62,35 @@ class OnboardingRepository {
   }
 
   /// User DB 호출
-  Future<Result<myUser.User, Exception>> getUser(userId) async {
+  Future<Result<myUser.User, Exception>> getUser(providerUID) async {
     try {
-      final result = await firebaseStoreService.getUserById(userId);
+      final result = await firebaseStoreService.getUserByPrviderUID(providerUID);
 
       switch (result) {
         case Success(value: final authUser):
           return Success(authUser);
+        case Failure(exception: final exception):
+          return Failure(exception);
+      }
+    } on Exception catch (error) {
+      return Failure(error); // 예외 발생 시 실패 반환
+    }
+  }
+
+  /// User Auth 호출
+  Future<Result<myUser.User, Exception>> getAuthUser() async {
+    try {
+      final result = await firebaseAuthService.getCurrentUser();
+
+      switch (result) {
+        case Success(value: final authUser):
+          final getUserDB = await firebaseStoreService.getUserById(authUser.uid);
+          switch (getUserDB) {
+            case Success(value: final userDB):
+              return Success(userDB);
+            case Failure(exception: final exception):
+              return Failure(exception);
+          }
         case Failure(exception: final exception):
           return Failure(exception);
       }

--- a/lib/src/datas/repositories/setting_repository.dart
+++ b/lib/src/datas/repositories/setting_repository.dart
@@ -28,13 +28,17 @@ class SettingRepository {
 
     switch (result) {
       case Success(value: final v):
-        final resetUser = await firebaseAuthService.resetCurrentUser();
-        switch (resetUser) {
-          case Success(value: final value):
-            return Success(value);
-          case Failure(exception: final exception):
-            return Failure(exception);
-        }
+        return await resetUser();
+      case Failure(exception: final exception):
+        return Failure(exception);
+    }
+  }
+
+  Future<Result<void, Exception>> resetUser() async {
+    final resetUser = await firebaseAuthService.resetCurrentUser();
+    switch (resetUser) {
+      case Success(value: final value):
+        return Success(value);
       case Failure(exception: final exception):
         return Failure(exception);
     }

--- a/lib/src/datas/repositories/setting_repository.dart
+++ b/lib/src/datas/repositories/setting_repository.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:green_field/src/datas/services/firebase_auth_service.dart';
+
+import '../../cores/error_handler/result.dart';
+import '../services/firebase_store_service.dart';
+
+class SettingRepository {
+  final FirebaseAuthService firebaseAuthService;
+  final FirebaseStoreService firebaseStoreService;
+
+  SettingRepository({required this.firebaseAuthService, required this.firebaseStoreService});
+
+  Future<Result<void, Exception>> signOut() async {
+    final result = await firebaseAuthService.signOut();
+
+    switch (result) {
+      case Success(value: final value):
+        return Success(value);
+      case Failure(exception: final exception):
+        return Failure(exception);
+    }
+  }
+
+  Future<Result<void, Exception>> deleteUser(String userId) async {
+    final result = await firebaseStoreService.deleteUserDB(userId);
+
+    switch (result) {
+      case Success(value: final v):
+        final resetUser = await firebaseAuthService.resetCurrentUser();
+        switch (resetUser) {
+          case Success(value: final value):
+            return Success(value);
+          case Failure(exception: final exception):
+            return Failure(exception);
+        }
+      case Failure(exception: final exception):
+        return Failure(exception);
+    }
+  }
+}
+
+final settingRepositoryProvider = Provider<SettingRepository>((ref) {
+  return SettingRepository(firebaseAuthService: FirebaseAuthService(FirebaseAuth.instance), firebaseStoreService: FirebaseStoreService(FirebaseFirestore.instance));
+});
+

--- a/lib/src/datas/services/firebase_auth_service.dart
+++ b/lib/src/datas/services/firebase_auth_service.dart
@@ -155,6 +155,17 @@ class FirebaseAuthService {
       return Failure(Exception('회원 탈퇴 실패: $e'));
     }
   }
+
+  /// 로그아웃 함수
+  Future<Result<void, Exception>> signOut() async {
+    try {
+      await _auth.signOut();
+      return Success(null);
+    } catch (e) {
+      return Failure(Exception('로그아웃 실패: $e'));
+    }
+  }
+
 }
 
 // Riverpod provider 정의

--- a/lib/src/datas/services/firebase_auth_service.dart
+++ b/lib/src/datas/services/firebase_auth_service.dart
@@ -33,6 +33,15 @@ class FirebaseAuthService {
     }
   }
 
+  Future<Result<void, Exception>> resetCurrentUser() async {
+    try {
+      await _auth.signOut();
+      return Success(null);
+    } catch (e) {
+      return Failure(Exception('사용자 초기화 실패: $e'));
+    }
+  }
+
   /// 카카오 로그인 - Token 전달
   Future<Result<Token, Exception>> signInWithKakao() async {
     try {

--- a/lib/src/datas/services/firebase_auth_service.dart
+++ b/lib/src/datas/services/firebase_auth_service.dart
@@ -134,6 +134,23 @@ class FirebaseAuthService {
     }
   }
 
+  /// 익명 로그인 함수
+  Future<Result<firebase_auth.User, Exception>> signInAnonymously() async {
+    try {
+      // Firebase에 익명으로 로그인
+      final userCredential = await _auth.signInAnonymously();
+      final user = userCredential.user;
+
+      if (user != null) {
+        return Success(user); // 성공 시 User 객체 반환
+      } else {
+        return Failure(Exception('익명 로그인 실패: 사용자 정보를 가져올 수 없습니다.'));
+      }
+    } catch (e) {
+      return Failure(Exception('익명 로그인 실패: $e'));
+    }
+  }
+
   /// Firebase Auth 생성
   Future<Result<firebase_auth.User, Exception>> connectFirebaseAuth(String provider, String idToken, String accessToken, String providerUID) async {
     try {

--- a/lib/src/datas/services/firebase_store_service.dart
+++ b/lib/src/datas/services/firebase_store_service.dart
@@ -22,12 +22,36 @@ class FirebaseStoreService {
   }
 
   /// Firestore에서 UserId로 사용자 데이터 가져오기
+  Future<Result<GFUser.User, Exception>> getUserByPrviderUID(String providerUID) async {
+    try {
+      print('UserId: $providerUID');
+
+      // simple_login_id가 userId와 일치하는 문서 쿼리
+      final querySnapshot = await _store
+          .collection('user')
+          .where('simple_login_id', isEqualTo: providerUID)
+          .get();
+
+      if (querySnapshot.docs.isNotEmpty) {
+        final userData = GFUser.User.fromMap(querySnapshot.docs.first.data());
+        return Success(userData);
+      } else {
+        return Failure(Exception(
+            'firebase_store_service _getUserBySimpleLoginId error: 사용자를 찾을 수 없습니다.'));
+      }
+    } catch (e) {
+      return Failure(Exception('사용자 데이터 가져오기 실패: $e'));
+    }
+  }
+
+  /// Firestore에서 UserId로 사용자 데이터 가져오기
   Future<Result<GFUser.User, Exception>> getUserById(String userId) async {
     try {
       final docSnapshot = await _store.collection('user').doc(userId).get();
 
       if (docSnapshot.exists) {
         final userData = GFUser.User.fromMap(docSnapshot.data()!);
+
         return Success(userData);
       } else {
         return Failure(Exception(
@@ -37,6 +61,7 @@ class FirebaseStoreService {
       return Failure(Exception('사용자 데이터 가져오기 실패: $e'));
     }
   }
+
 
   /// Notice Collection 생성 및 Notice 데이터 추가
   Future<Result<Notice, Exception>> createNoticeDB(Notice notice, GFUser.User user) async {

--- a/lib/src/datas/services/firebase_store_service.dart
+++ b/lib/src/datas/services/firebase_store_service.dart
@@ -120,11 +120,12 @@ class FirebaseStoreService {
   }
 
   /// Notice List 가져오기
-  Future<Result<List<Notice>, Exception>> getNoticeList(GFUser.User user) async {
+  Future<Result<List<Notice>, Exception>> getNoticeList(GFUser.User? user) async {
     try {
+      print("user : $user");
       // 기본 쿼리
       var query = _store
-          .collection('Campus').doc(user.campus == '익명' ? '관악' : user.campus)
+          .collection('Campus').doc(user == null ? '관악' : user.campus)
           .collection('Notice').orderBy('created_at', descending: true)
           .limit(15);
 

--- a/lib/src/datas/services/firebase_store_service.dart
+++ b/lib/src/datas/services/firebase_store_service.dart
@@ -13,7 +13,7 @@ class FirebaseStoreService {
   Future<Result<GFUser.User, Exception>> createUserDB(GFUser.User user) async {
     try {
       // User 컬렉션에 사용자 데이터 추가
-      await _store.collection('user').doc(user.id).set(user.toMap());
+      await _store.collection('User').doc(user.id).set(user.toMap());
 
       return Success(user);
     } catch (e) {
@@ -28,7 +28,7 @@ class FirebaseStoreService {
 
       // simple_login_id가 userId와 일치하는 문서 쿼리
       final querySnapshot = await _store
-          .collection('user')
+          .collection('User')
           .where('simple_login_id', isEqualTo: providerUID)
           .get();
 
@@ -47,7 +47,7 @@ class FirebaseStoreService {
   /// Firestore에서 UserId로 사용자 데이터 가져오기
   Future<Result<GFUser.User, Exception>> getUserById(String userId) async {
     try {
-      final docSnapshot = await _store.collection('user').doc(userId).get();
+      final docSnapshot = await _store.collection('User').doc(userId).get();
 
       if (docSnapshot.exists) {
         final userData = GFUser.User.fromMap(docSnapshot.data()!);
@@ -61,6 +61,18 @@ class FirebaseStoreService {
       return Failure(Exception('사용자 데이터 가져오기 실패: $e'));
     }
   }
+
+  /// UserDB 삭제 함수
+  Future<Result<void, Exception>> deleteUserDB(String userId) async {
+    try {
+      // Firestore에서 사용자 문서 삭제
+      await _store.collection('User').doc(userId).delete();
+      return Success(null); // 성공적으로 삭제되었음을 나타냄
+    } catch (e) {
+      return Failure(Exception('사용자 데이터 삭제 실패: $e'));
+    }
+  }
+
 
 
   /// Notice Collection 생성 및 Notice 데이터 추가

--- a/lib/src/model/token.dart
+++ b/lib/src/model/token.dart
@@ -1,22 +1,26 @@
 class Token {
-  String? provider;
-  String? idToken;
-  String? accessToken;
+  String provider;
+  String providerUID;
+  String idToken;
+  String accessToken;
 
   Token({
-  this.provider,
-  this.idToken,
-  this.accessToken,
+  required this.provider,
+  required this.providerUID,
+  required this.idToken,
+  required this.accessToken,
   });
 
   static Token fromMap(Map<String, dynamic> map) {
     // null 체크 및 기본값 설정
     String provider = map['provider'];
+    String providerUID = map['providerUID'];
     String idToken = map['id_token'];
     String accessToken = map['access_token'];
 
     return Token(
       provider: provider,
+      providerUID: providerUID,
       idToken: idToken,
       accessToken: accessToken,
     );

--- a/lib/src/model/user.dart
+++ b/lib/src/model/user.dart
@@ -1,6 +1,7 @@
 class User {
   String id;
-  String providerId;
+  String simpleLoginProvider;
+  String simpleLoginId;
   String userType;
   String campus;
   String course;
@@ -11,7 +12,8 @@ class User {
 
   User({
     required this.id,
-    required this.providerId,
+    required this.simpleLoginProvider,
+    required this.simpleLoginId,
     this.userType = "student",
     required this.campus,
     required this.course,
@@ -24,7 +26,8 @@ class User {
   Map<String, dynamic> toMap() {
     return {
       'id': id,
-      'simple_login_id': providerId,
+      'simple_login_provider': simpleLoginProvider,
+      'simple_login_id': simpleLoginId,
       'user_type': userType,
       'campus': campus,
       'course': course,
@@ -38,14 +41,16 @@ class User {
   static User fromMap(Map<String, dynamic> map) {
     // null 체크 및 기본값 설정
     String id = map['id'] ?? '';
-    String simpleLoginId = map['simple_login_id'] ?? 'unknown';
-    String campus = map['campus'] ?? 'unknown';
-    String course = map['course'] ?? 'unknown';
-    String name = map['name'] ?? 'unknown';
+    String simpleLoginProvider = map['simple_login_provider'] ?? '(익명)';
+    String simpleLoginId = map['simple_login_id'] ?? '(익명)';
+    String campus = map['campus'] ?? '(익명)';
+    String course = map['course'] ?? '(익명)';
+    String name = map['name'] ?? '(익명)';
 
     return User(
       id: id,
-      providerId: simpleLoginId,
+      simpleLoginProvider: simpleLoginProvider,
+      simpleLoginId: simpleLoginId,
       userType: map['user_type'] ?? "student",
       campus: campus,
       course: course,

--- a/lib/src/utilities/components/greefield_login_alert_dialog.dart
+++ b/lib/src/utilities/components/greefield_login_alert_dialog.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../cores/error_handler/result.dart';
+import '../../viewmodels/setting/setting_view_model.dart';
+
+class GreenFieldLoginAlertDialog extends StatelessWidget {
+  final WidgetRef ref;
+
+  const GreenFieldLoginAlertDialog({super.key, required this.ref});
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoAlertDialog(
+      title: Text('로그인 후 서비스를 이용해보세요'),
+      content: Text('다양한 서비스를 이용할 수 있어요!'),
+      actions: [
+        CupertinoDialogAction(
+          child: Text("취소", style: TextStyle(color: CupertinoColors.inactiveGray)),
+          onPressed: () => Navigator.pop(context),
+        ),
+        CupertinoDialogAction(
+          child: Text("확인", style: TextStyle(color: CupertinoColors.activeBlue)),
+          onPressed: () async {
+            Navigator.pop(context);
+            final result = await ref.read(settingViewModelProvider.notifier).resetUser();
+
+            switch (result) {
+              case Success():
+                context.go('/signIn');
+              case Failure(exception: final e):
+                showDialog(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: Text('익명 로그인 초기화 실패'),
+                    content: Text('에러 발생: $e'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text('확인'),
+                      ),
+                    ],
+                  ),
+                );
+            }
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/utilities/components/greenfield_images_detail.dart
+++ b/lib/src/utilities/components/greenfield_images_detail.dart
@@ -9,33 +9,66 @@ import 'package:green_field/src/utilities/extensions/theme_data_extension.dart';
 
 import '../../cores/image_type/image_type.dart';
 
-class GreenFieldImagesDetail extends StatelessWidget {
+class GreenFieldImagesDetail extends StatefulWidget {
   const GreenFieldImagesDetail({
     super.key,
     required this.tags,
     required this.initialIndex,
   });
+
   final List<String?> tags;
   final int initialIndex;
+
+  @override
+  _GreenFieldImagesDetailState createState() => _GreenFieldImagesDetailState();
+}
+
+class _GreenFieldImagesDetailState extends State<GreenFieldImagesDetail> {
+  late int currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    currentIndex = widget.initialIndex;
+  }
+
+  void _updateTitle(int index) {
+    setState(() {
+      currentIndex = index;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    final heroWidgets = tags
+    final heroWidgets = widget.tags
         .map((path) => Hero(
-        tag: path!,
-        child: CachedNetworkImage(
-          imageUrl: path.toString(),
-        ),
+      tag: path!,
+      child: CachedNetworkImage(
+        imageUrl: path.toString(),
       ),
-    )
+    ))
         .toList();
 
     return Scaffold(
-      appBar: GreenFieldAppBar(backgGroundColor: Theme.of(context).appColors.gfWhiteColor, title: ''),
       backgroundColor: Theme.of(context).appColors.gfWhiteColor,
       body: SafeArea(
-        child: DetailScreenPageView(
-          widgets: heroWidgets,
-          initialIndex: initialIndex,
+        child: Stack(
+          children: [
+            DetailScreenPageView(
+              widgets: heroWidgets,
+              initialIndex: widget.initialIndex,
+              onPageChanged: _updateTitle, // 페이지 변경 시 호출
+            ),
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: GreenFieldAppBar(
+                backgGroundColor: Theme.of(context).appColors.gfWhiteColor.withOpacity(0.5),
+                title: '${currentIndex + 1}/${heroWidgets.length}',
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -47,10 +80,12 @@ class DetailScreenPageView extends StatefulWidget {
     super.key,
     required this.widgets,
     required this.initialIndex,
+    required this.onPageChanged,
   });
 
   final List<Widget> widgets;
   final int initialIndex;
+  final ValueChanged<int> onPageChanged;
 
   @override
   State<DetailScreenPageView> createState() => _DetailScreenPageView();
@@ -119,7 +154,12 @@ class _DetailScreenPageView extends State<DetailScreenPageView>
         Expanded(
           child: PageView.builder(
             controller: _pageViewController,
-            onPageChanged: _handlePageViewChanged,
+            onPageChanged: (index) {
+              widget.onPageChanged(index); // 페이지 변경 시 호출
+              setState(() {
+                _tabController.index = index;
+              });
+            },
             itemCount: widget.widgets.length,
             itemBuilder: (context, index) {
               return GestureDetector(
@@ -136,45 +176,7 @@ class _DetailScreenPageView extends State<DetailScreenPageView>
             },
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 40),
-          child: PageIndicator(
-            tabController: _tabController,
-          ),
-        ),
       ],
-    );
-  }
-
-  void _handlePageViewChanged(int currentPageIndex) {
-    _tabController.index = currentPageIndex;
-  }
-}
-
-class PageIndicator extends StatelessWidget {
-  const PageIndicator({
-    super.key,
-    required this.tabController,
-  });
-
-  final TabController tabController;
-
-  @override
-  Widget build(BuildContext context) {
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          TabPageSelector(
-            controller: tabController,
-            color: Theme.of(context).appColors.gfBackGroundColor,
-            selectedColor: Theme.of(context).appColors.gfMainColor,
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/src/utilities/components/greenfield_list.dart
+++ b/lib/src/utilities/components/greenfield_list.dart
@@ -4,6 +4,7 @@ import '../design_system/app_icons.dart';
 import '../design_system/app_texts.dart';
 import 'package:green_field/src/utilities/extensions/theme_data_extension.dart';
 
+import '../extensions/image_dimension_parser.dart';
 import 'greenfield_cached_network_image.dart';
 
 class GreenFieldList extends StatelessWidget {
@@ -128,9 +129,7 @@ class GreenFieldList extends StatelessWidget {
                   if (imageUrl.isNotEmpty)
                     ClipRRect(
                         borderRadius: BorderRadius.circular(8),
-                        child: Transform.scale(
-                          scale: 1.5,
-                            child: GreenFieldCachedNetworkImage(imageUrl: imageUrl, width: 60, height: 60))
+                        child: GreenFieldCachedNetworkImage(imageUrl: imageUrl, width: 60, height: 60, scaleEffect: ImageDimensionParser().parseDimensions(imageUrl),)
                     )
                 ],
               ),

--- a/lib/src/utilities/extensions/image_dimension_parser.dart
+++ b/lib/src/utilities/extensions/image_dimension_parser.dart
@@ -32,4 +32,25 @@ class ImageDimensionParser {
     }
     return 1.0;
   }
+
+  bool isWidthSizeBiggerThanHeight(String? imageUrl) {
+    if (imageUrl == null) return false; // Default scale if URL is null
+
+    // Regular expression to match width and height
+    RegExp regExp = RegExp(r'width=(\d+)_height=(\d+)');
+    Match? match = regExp.firstMatch(imageUrl);
+
+    if (match != null) {
+      int width = int.parse(match.group(1)!);
+      int height = int.parse(match.group(2)!);
+      print('width: $width, hieght: $height');
+
+      if (width > height) {
+        return true;
+      }
+    } else {
+      return false;
+    }
+    return false;
+  }
 }

--- a/lib/src/viewmodels/home/home_view_model.dart
+++ b/lib/src/viewmodels/home/home_view_model.dart
@@ -23,26 +23,6 @@ class HomeViewModel extends _$HomeViewModel {
     );
   }
 
-  /// User DB 호출
-  Future<Result<myUser.User, Exception>> getUser(String userId) async {
-    final authRepository = ref.read(firebaseAuthServiceProvider);
-    final firebaseUser = authRepository.currentUser;
-
-    if (firebaseUser != null && firebaseUser.providerData.isNotEmpty) {
-      final result = await ref
-          .read(onboardingRepositoryProvider)
-          .getUser(userId);
-
-      switch (result) {
-        case Success(value: final user):
-          return Success(user);
-        case Failure(exception: final e):
-          return Failure(e);
-      }
-    } else {
-      return Failure(Exception('사용자가 로그인되어 있지 않거나 제공자 데이터가 없습니다.'));
-    }
-  }
 }
 
 

--- a/lib/src/viewmodels/login/login_view_model.dart
+++ b/lib/src/viewmodels/login/login_view_model.dart
@@ -11,7 +11,7 @@ class LoginViewModel extends _$LoginViewModel {
 
   @override
   Future<Token> build() async {
-    return Token();
+    return Token(provider: '', providerUID: '', idToken: '', accessToken: '');
   }
 
   Future<Result<Token, Exception>> signInWithKakao() async {

--- a/lib/src/viewmodels/login/login_view_model.dart
+++ b/lib/src/viewmodels/login/login_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart' as firebase_auth;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:green_field/src/cores/error_handler/result.dart';
 import '../../datas/repositories/login_repository.dart';
@@ -45,6 +46,21 @@ class LoginViewModel extends _$LoginViewModel {
       case Success(value: final token):
         state = AsyncData(token);
         return Success(token);
+      case Failure(exception: final e):
+        state = AsyncError(e, StackTrace.current);
+        return Failure(Exception('애플 로그인 실패: $e'));
+    }
+  }
+
+  Future<Result<firebase_auth.User, Exception>> signInWithAnonymously() async {
+    state = AsyncLoading();
+    final result = await ref.read(loginRepositoryProvider).signInWithAnonymously();
+
+    switch (result) {
+      case Success(value: final v):
+        print(v.metadata);
+        state = AsyncData( Token(provider: '', providerUID: '', idToken: '', accessToken: ''));
+        return Success(v);
       case Failure(exception: final e):
         state = AsyncError(e, StackTrace.current);
         return Failure(Exception('애플 로그인 실패: $e'));

--- a/lib/src/viewmodels/notice/notice_edit_view_model.g.dart
+++ b/lib/src/viewmodels/notice/notice_edit_view_model.g.dart
@@ -7,7 +7,7 @@ part of 'notice_edit_view_model.dart';
 // **************************************************************************
 
 String _$noticeEditViewModelHash() =>
-    r'058b053b3c9516d15ac77fde1a81b10accb70326';
+    r'1c25149b6f8aa2c5da2cb3c9ab6df1d06a1e0654';
 
 /// See also [NoticeEditViewModel].
 @ProviderFor(NoticeEditViewModel)

--- a/lib/src/viewmodels/notice/notice_view_model.dart
+++ b/lib/src/viewmodels/notice/notice_view_model.dart
@@ -40,11 +40,10 @@ class NoticeViewModel extends _$NoticeViewModel {
   Future<Result<List<Notice>, Exception>> getNoticeList() async {
     state = AsyncLoading();
     final userState = ref.watch(onboardingViewModelProvider);
-    if (userState.value == null) return Failure(Exception('유저가 없습니다.'));
 
     final result = await ref
         .read(noticeRepositoryProvider)
-        .getNoticeList(userState.value!);
+        .getNoticeList(userState.value);
 
     switch (result) {
       case Success(value: final noticeList):

--- a/lib/src/viewmodels/onboarding/onboarding_view_model.dart
+++ b/lib/src/viewmodels/onboarding/onboarding_view_model.dart
@@ -165,7 +165,6 @@ class OnboardingViewModel extends _$OnboardingViewModel {
 
   /// User State 초기화
   Future<Result<void, Exception>> resetUserState() async {
-    state = AsyncLoading();
     try {
       final authRepository = ref.read(firebaseAuthServiceProvider);
       final firebaseUser = authRepository.currentUser;

--- a/lib/src/viewmodels/onboarding/onboarding_view_model.dart
+++ b/lib/src/viewmodels/onboarding/onboarding_view_model.dart
@@ -162,6 +162,25 @@ class OnboardingViewModel extends _$OnboardingViewModel {
       return Failure(Exception('사용자가 로그인되어 있지 않거나 제공자 데이터가 없습니다.'));
     }
   }
+
+  /// User State 초기화
+  Future<Result<void, Exception>> resetUserState() async {
+    state = AsyncLoading();
+    try {
+      final authRepository = ref.read(firebaseAuthServiceProvider);
+      final firebaseUser = authRepository.currentUser;
+
+      if (firebaseUser != null) {
+        currentUser = null;
+        state = AsyncData(null);
+        return Success(null);
+      } else {
+        return Failure(Exception('사용자가 로그인되어 있지 않습니다.'));
+      }
+    } catch (e) {
+      return Failure(Exception('User 상태 초기화 실패: $e'));
+    }
+  }
 }
 
 /// courseProvider 생성

--- a/lib/src/viewmodels/setting/setting_view_model.dart
+++ b/lib/src/viewmodels/setting/setting_view_model.dart
@@ -54,4 +54,24 @@ class SettingViewModel extends _$SettingViewModel {
     }
   }
 
+
+  Future<Result<void, Exception>> resetUser() async {
+    state = AsyncLoading();
+    try {
+      final result = await ref.read(settingRepositoryProvider).resetUser();
+
+      switch (result) {
+        case Success():
+          state = AsyncData(null); // 탈퇴 후 상태 초기화
+          return Success(null);
+
+        case Failure(exception: final e):
+          state = AsyncError(e, StackTrace.current);
+          return Failure(Exception('익명 로그인 초기화 실패: $e'));
+      }
+    } catch (e, stackTrace) {
+      state = AsyncError(e, stackTrace);
+      return Failure(Exception('익명 로그인 초기화 중 예외 발생: $e'));
+    }
+  }
 }

--- a/lib/src/viewmodels/setting/setting_view_model.dart
+++ b/lib/src/viewmodels/setting/setting_view_model.dart
@@ -1,0 +1,55 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../cores/error_handler/result.dart';
+import '../../datas/repositories/login_repository.dart';
+
+part 'setting_view_model.g.dart'; // 생성된 코드를 위한 파일
+
+@Riverpod(keepAlive: true)
+class SettingViewModel extends _$SettingViewModel {
+  @override
+  Future<void> build() async {
+    return;
+  }
+
+  Future<Result<void, Exception>> signOut() async {
+    state = AsyncLoading();
+    try {
+      final result = await ref.read(loginRepositoryProvider).signOut();
+
+      switch (result) {
+        case Success():
+          state = AsyncData(null);
+          return Success(null);
+
+        case Failure(exception: final e):
+          state = AsyncError(e, StackTrace.current);
+          return Failure(Exception('로그아웃 실패: $e'));
+      }
+    } catch (e, stackTrace) {
+      state = AsyncError(e, stackTrace);
+      return Failure(Exception('로그아웃 중 예외 발생: $e'));
+    }
+  }
+
+  Future<Result<void, Exception>> deleteUser() async {
+    state = AsyncLoading();
+    try {
+      final result = await ref.read(loginRepositoryProvider).deleteUser();
+
+      switch (result) {
+        case Success():
+          state = AsyncData(null); // 탈퇴 후 상태 초기화
+          return Success(null);
+
+        case Failure(exception: final e):
+          state = AsyncError(e, StackTrace.current);
+          return Failure(Exception('회원 탈퇴 실패: $e'));
+      }
+    } catch (e, stackTrace) {
+      state = AsyncError(e, stackTrace);
+      return Failure(Exception('회원 탈퇴 중 예외 발생: $e'));
+    }
+  }
+
+}

--- a/lib/src/viewmodels/setting/setting_view_model.dart
+++ b/lib/src/viewmodels/setting/setting_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:green_field/src/datas/repositories/setting_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../cores/error_handler/result.dart';
@@ -15,7 +16,7 @@ class SettingViewModel extends _$SettingViewModel {
   Future<Result<void, Exception>> signOut() async {
     state = AsyncLoading();
     try {
-      final result = await ref.read(loginRepositoryProvider).signOut();
+      final result = await ref.read(settingRepositoryProvider).signOut();
 
       switch (result) {
         case Success():
@@ -32,10 +33,10 @@ class SettingViewModel extends _$SettingViewModel {
     }
   }
 
-  Future<Result<void, Exception>> deleteUser() async {
+  Future<Result<void, Exception>> deleteUser(String userId) async {
     state = AsyncLoading();
     try {
-      final result = await ref.read(loginRepositoryProvider).deleteUser();
+      final result = await ref.read(settingRepositoryProvider).deleteUser(userId);
 
       switch (result) {
         case Success():
@@ -43,6 +44,7 @@ class SettingViewModel extends _$SettingViewModel {
           return Success(null);
 
         case Failure(exception: final e):
+          print(e);
           state = AsyncError(e, StackTrace.current);
           return Failure(Exception('회원 탈퇴 실패: $e'));
       }

--- a/lib/src/viewmodels/setting/setting_view_model.g.dart
+++ b/lib/src/viewmodels/setting/setting_view_model.g.dart
@@ -1,26 +1,26 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'notice_view_model.dart';
+part of 'setting_view_model.dart';
 
 // **************************************************************************
 // RiverpodGenerator
 // **************************************************************************
 
-String _$noticeViewModelHash() => r'73242c2521180cb639f7d0f6b27edb9ac60fa5ae';
+String _$settingViewModelHash() => r'c7b1b11cd308717213b5cc5defb14e252edfc2e4';
 
-/// See also [NoticeViewModel].
-@ProviderFor(NoticeViewModel)
-final noticeViewModelProvider =
-    AsyncNotifierProvider<NoticeViewModel, List<Notice>?>.internal(
-  NoticeViewModel.new,
-  name: r'noticeViewModelProvider',
+/// See also [SettingViewModel].
+@ProviderFor(SettingViewModel)
+final settingViewModelProvider =
+    AsyncNotifierProvider<SettingViewModel, void>.internal(
+  SettingViewModel.new,
+  name: r'settingViewModelProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$noticeViewModelHash,
+      : _$settingViewModelHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$NoticeViewModel = AsyncNotifier<List<Notice>?>;
+typedef _$SettingViewModel = AsyncNotifier<void>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/views/home/home_view.dart
+++ b/lib/src/views/home/home_view.dart
@@ -9,6 +9,7 @@ import 'package:green_field/src/utilities/extensions/theme_data_extension.dart';
 import 'package:green_field/src/viewmodels/home/home_view_model.dart';
 import 'package:green_field/src/views/home/sections/expiring_soon_recruit_section.dart';
 import 'package:green_field/src/views/home/sections/notice_carousel_section.dart';
+import '../../utilities/components/greefield_login_alert_dialog.dart';
 import '../../utilities/design_system/app_icons.dart';
 import '../../utilities/design_system/app_texts.dart';
 import '../../viewmodels/onboarding/onboarding_view_model.dart';
@@ -25,7 +26,7 @@ class HomeView extends ConsumerStatefulWidget {
 class _HomeViewState extends ConsumerState<HomeView> {
   @override
   Widget build(BuildContext context) {
-    final onboardingState = ref.watch(onboardingViewModelProvider);
+    final userState = ref.watch(onboardingViewModelProvider);
     final noticeState = ref.watch(noticeViewModelProvider);
 
     return Scaffold(
@@ -41,7 +42,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Skeletonizer(
-                    enabled: onboardingState.isLoading,
+                    enabled: userState.isLoading,
                     effect: ShimmerEffect(
                       baseColor: Theme.of(context).appColors.gfMainBackGroundColor,
                       highlightColor: Theme.of(context).appColors.gfWhiteColor,
@@ -59,17 +60,17 @@ class _HomeViewState extends ConsumerState<HomeView> {
                           height: 40,
                         ),
                         title: Text(
-                          onboardingState.value?.name != null &&
-                              onboardingState.value!.name.isNotEmpty
-                              ? onboardingState.value!.name
+                          userState.value?.name != null &&
+                              userState.value!.name.isNotEmpty
+                              ? userState.value!.name
                               : '(익명)',
                           style: AppTextsTheme.main().gfTitle1.copyWith(
                             color: Theme.of(context).appColors.gfBlackColor,
                           ),
                         ),
                         subtitle: Text(
-                          onboardingState.value != null
-                              ? '${onboardingState.value!.campus} 캠퍼스 ${onboardingState.value!.course}'
+                          userState.value != null
+                              ? '${userState.value!.campus} 캠퍼스 ${userState.value!.course}'
                               : '서비스를 이용하려면 로그인해주세요.', // 실패 시 기본 메시지
                           style: AppTextsTheme.main().gfBody5.copyWith(
                             color: Theme.of(context).appColors.gfGray400Color,
@@ -98,7 +99,16 @@ class _HomeViewState extends ConsumerState<HomeView> {
                             Spacer(),
                             GestureDetector(
                               onTap: () {
-                                context.go('/home/notice');
+                                if (userState.value == null) {
+                                  showCupertinoDialog(
+                                    context: context,
+                                    builder: (BuildContext context) {
+                                      return GreenFieldLoginAlertDialog(ref: ref);
+                                    },
+                                  );
+                                } else {
+                                  context.go('/home/notice');
+                                }
                               },
                               child: Text(
                                 "더보기 >",
@@ -112,7 +122,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                           ],
                         ),
                         SizedBox(height: 5),
-                        noticeState.isLoading || onboardingState.isLoading
+                        noticeState.isLoading || userState.isLoading
                             ? Skeletonizer.zone(
                                 effect: ShimmerEffect(
                                   baseColor: Theme.of(context).appColors.gfMainBackGroundColor,

--- a/lib/src/views/home/home_view.dart
+++ b/lib/src/views/home/home_view.dart
@@ -112,7 +112,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                           ],
                         ),
                         SizedBox(height: 5),
-                        noticeState.isLoading
+                        noticeState.isLoading || onboardingState.isLoading
                             ? Skeletonizer.zone(
                                 effect: ShimmerEffect(
                                   baseColor: Theme.of(context).appColors.gfMainBackGroundColor,

--- a/lib/src/views/home/sections/external_link_section.dart
+++ b/lib/src/views/home/sections/external_link_section.dart
@@ -19,13 +19,13 @@ class ExternalLinkSection extends StatelessWidget {
             _launchURL('https://sesac.seoul.kr/');
           }),
           iconText(AppIcons.restaurant, '식당 안내', () {
-            _launchURL('https://sesac.seoul.kr/');
+            _launchURL('http://docs.google.com/spreadsheets/d/1cQGLdiNgArwWoY50ROpJgYw4XCNihhvpJscOityRRUo/edit');
           }),
           iconText(AppIcons.file, '강의 자료', () {
-            _launchURL('https://sesac.seoul.kr/');
+            _launchURL('https://healthyclass.kr/home');
           }),
           iconText(AppIcons.discord, '디스코드', () {
-            _launchURL('https://sesac.seoul.kr/');
+            _launchURL('https://discord.gg/7K96dDVs');
           }),
         ],
       ),

--- a/lib/src/views/home/sections/notice_carousel_section.dart
+++ b/lib/src/views/home/sections/notice_carousel_section.dart
@@ -4,13 +4,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/utilities/extensions/theme_data_extension.dart';
+import 'package:green_field/src/viewmodels/onboarding/onboarding_view_model.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
+import '../../../cores/error_handler/result.dart';
+import '../../../utilities/components/greefield_login_alert_dialog.dart';
 import '../../../utilities/components/greenfield_cached_network_image.dart';
 import '../../../utilities/design_system/app_icons.dart';
 import '../../../utilities/design_system/app_texts.dart';
 import '../../../utilities/extensions/image_dimension_parser.dart';
 import '../../../viewmodels/notice/notice_view_model.dart';
+import '../../../viewmodels/setting/setting_view_model.dart';
 
 class NoticeCarouselSection extends ConsumerStatefulWidget {
   NoticeCarouselSection({super.key});
@@ -24,6 +28,7 @@ class NoticeCarouselSectionState extends ConsumerState<NoticeCarouselSection> {
 
   @override
   Widget build(BuildContext context) {
+    final userState = ref.watch(onboardingViewModelProvider);
     final noticeState = ref.watch(noticeViewModelProvider);
 
     if (noticeState.value!.isNotEmpty) {
@@ -41,7 +46,16 @@ class NoticeCarouselSectionState extends ConsumerState<NoticeCarouselSection> {
                       child: CupertinoButton(
                         padding: EdgeInsets.zero,
                         onPressed: () {
-                          context.go('/home/notice/detail/${notice.id}');
+                          if (userState.value == null) {
+                            showCupertinoDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                return GreenFieldLoginAlertDialog(ref: ref);
+                              },
+                            );
+                          } else {
+                            context.go('/home/notice/detail/${notice.id}');
+                          }
                         },
                         child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/views/login/login_view.dart
+++ b/lib/src/views/login/login_view.dart
@@ -7,6 +7,7 @@ import 'package:green_field/src/utilities/components/greenfield_loading_widget.d
 import 'package:green_field/src/viewmodels/onboarding/onboarding_view_model.dart';
 import 'package:lottie/lottie.dart';
 import 'package:green_field/src/viewmodels/login/login_view_model.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../../cores/error_handler/result.dart';
 import '../../utilities/design_system/app_colors.dart';
 import '../../utilities/design_system/app_icons.dart';
@@ -127,8 +128,31 @@ class _LoginViewState extends ConsumerState<LoginView> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         CupertinoButton(
-                          onPressed: () {
-                            context.go('/home');
+                          onPressed: () async {
+                            final result = await ref
+                                .read(loginViewModelProvider.notifier)
+                                .signInWithAnonymously();
+
+                            switch (result) {
+                              case Success():
+                              // context.go('/home');
+
+                              case Failure(exception: final e):
+                                showDialog(
+                                  context: context,
+                                  builder: (context) => AlertDialog(
+                                    title: Text('로그인 실패'),
+                                    content: Text('에러 발생'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () => Navigator.of(context).pop(),
+                                        child: Text('확인'),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                            }
+
                           },
                           child: Text(
                             '로그인 없이 둘러보기',
@@ -138,7 +162,13 @@ class _LoginViewState extends ConsumerState<LoginView> {
                         ),
                         SizedBox(width: 10),
                         CupertinoButton(
-                          onPressed: () {},
+                          onPressed: () async {
+                              if (await canLaunch('https://open.kakao.com/o/sv8nyahh')) {
+                                await launch('https://open.kakao.com/o/sv8nyahh');
+                              } else {
+                                throw 'Could not launch';
+                              }
+                          },
                           child: Text(
                             '문의하기',
                             style: AppTextsTheme.main().gfCaption1.copyWith(

--- a/lib/src/views/onboarding/onboarding_view.dart
+++ b/lib/src/views/onboarding/onboarding_view.dart
@@ -106,6 +106,7 @@ class _OnboardingViewState extends ConsumerState<OnboardingView> {
                             tokenState.value?.provider ?? '',
                             tokenState.value?.idToken ?? '',
                             tokenState.value?.accessToken ?? '',
+                            tokenState.value?.providerUID ?? '',
                           );
 
                       switch (result) {

--- a/lib/src/views/setting/setting_view.dart
+++ b/lib/src/views/setting/setting_view.dart
@@ -4,8 +4,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:green_field/src/utilities/components/greenfield_app_bar.dart';
 import 'package:green_field/src/utilities/extensions/theme_data_extension.dart';
+import 'package:green_field/src/viewmodels/setting/setting_view_model.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../cores/error_handler/result.dart';
+import '../../utilities/components/greenfield_loading_widget.dart';
 import '../../utilities/components/greenfield_user_info_widget.dart';
 import '../../utilities/design_system/app_colors.dart';
 import '../../utilities/design_system/app_icons.dart';
@@ -24,7 +27,8 @@ class _SettingViewState extends ConsumerState<SettingView> {
 
   @override
   Widget build(BuildContext context) {
-    final onboardingState = ref.watch(onboardingViewModelProvider);
+    final userState = ref.watch(onboardingViewModelProvider);
+    final settingState = ref.watch(settingViewModelProvider);
 
     return Scaffold(
       backgroundColor: Theme.of(context).appColors.gfBackGroundColor, // 배경색 설정
@@ -39,90 +43,132 @@ class _SettingViewState extends ConsumerState<SettingView> {
           context.pop();
         },
       ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            SizedBox(height: 10),
-            CupertinoListSection.insetGrouped(
+      body: Stack(
+        children: [
+          SafeArea(
+            child: Column(
               children: [
-                CupertinoListTile(
-                  title: Text('닉네임'),
-                  trailing: Text(onboardingState.value?.name ?? ('익명')),
+                SizedBox(height: 10),
+                CupertinoListSection.insetGrouped(
+                  children: [
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.person_crop_rectangle),
+                      title: Text('닉네임'),
+                      trailing: Text(userState.value?.name ?? ('익명')),
+                    ),
+                    CupertinoListTile(
+                      leading: Image.asset(
+                        color: Theme.of(context).appColors.gfMainColor,
+                        AppIcons.sesac,
+                        width: 24,
+                        height: 24,
+                      ),
+                      title: Text('캠퍼스'),
+                      trailing: Text(userState.value?.campus ?? ('익명')),
+                    ),
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.tag),
+                      title: Text('유형'),
+                      trailing: Text(userState.value?.userType ?? ('익명')),
+                    ),
+                  ],
                 ),
-                CupertinoListTile(
-                  title: Text('캠퍼스'),
-                  trailing: Text(onboardingState.value?.campus ?? ('익명')),
-                ),
-                CupertinoListTile(
-                  title: Text('유형'),
-                  trailing: Text(onboardingState.value?.userType ?? ('익명')),
-                ),
-              ],
-            ),
-            CupertinoListSection.insetGrouped(
-              children: [
-                CupertinoListTile(
-                  title: Text('사용약관'),
-                  trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
-                  onTap: () {
-                    _launchURL('https://bulmang.notion.site/1a0d2c07070480638ee3f48aff0adae3?pvs=73');
-                  },
-                ),
-                CupertinoListTile(
-                  title: Text('개인정보처리방침'),
-                  trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
-                  onTap: () {
-                    _launchURL('https://bulmang.notion.site/1a0d2c07070480329802f0ec3b59a76e');
-                  },
-                ),
-              ],
-            ),
-            CupertinoListSection.insetGrouped(
-              children: [
-                CupertinoListTile(
-                  title: Text('고객센터'),
-                  trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
-                  onTap: () {
-                    _launchURL('https://open.kakao.com/o/sv8nyahh');
-                  },
-                ),
-              ],
-            ),
-            CupertinoListSection.insetGrouped(
-              children: [
-                CupertinoListTile(
-                  title: Text('로그아웃'),
-                  onTap: () {
-                    _showIOSDialog(
-                      context: context,
-                      title: "로그아웃",
-                      body: '정말 로그아웃할까요?',
-                      onConfirm: () {
-
+                CupertinoListSection.insetGrouped(
+                  children: [
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.doc_plaintext),
+                      title: Text('사용약관'),
+                      trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
+                      onTap: () {
+                        _launchURL('https://bulmang.notion.site/1a0d2c07070480638ee3f48aff0adae3?pvs=73');
                       },
-                    );
-                  }
-                ),
-                CupertinoListTile(
-                  title: Text(
-                    '탈퇴하기',
-                    style: TextStyle(color: CupertinoColors.systemRed),
-                  ),
-                  onTap: () {
-                    _showIOSDialog(
-                      context: context,
-                      title: "회원 탈퇴",
-                      body: '정말 탈퇴할까요?',
-                      onConfirm: () {
-
+                    ),
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.doc_person),
+                      title: Text('개인정보처리방침'),
+                      trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
+                      onTap: () {
+                        _launchURL('https://bulmang.notion.site/1a0d2c07070480329802f0ec3b59a76e');
                       },
-                    );
-                  },
+                    ),
+                  ],
+                ),
+                CupertinoListSection.insetGrouped(
+                  children: [
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.exclamationmark_bubble),
+                      title: Text('고객센터'),
+                      trailing: Icon(CupertinoIcons.chevron_forward, color: CupertinoColors.inactiveGray),
+                      onTap: () {
+                        _launchURL('https://open.kakao.com/o/sv8nyahh');
+                      },
+                    ),
+                  ],
+                ),
+                CupertinoListSection.insetGrouped(
+                  children: [
+                    CupertinoListTile(
+                        leading: Icon(CupertinoIcons.square_arrow_left),
+                      title: Text('로그아웃'),
+                      onTap: () {
+                        _showIOSDialog(
+                          context: context,
+                          title: "로그아웃",
+                          body: '정말 로그아웃할까요?',
+                          onConfirm: () async {
+                            final result = await ref
+                                .read(settingViewModelProvider.notifier)
+                                .signOut();
+
+                            switch (result) {
+                              case Success():
+                                context.go('/signIn');
+
+                              case Failure(exception: final e):
+                                showDialog(
+                                  context: context,
+                                  builder: (context) => AlertDialog(
+                                    title: Text('로그인 실패'),
+                                    content: Text('에러 발생: $e'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () => Navigator.of(context).pop(),
+                                        child: Text('확인'),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                            }
+                          },
+                        );
+                      }
+                    ),
+                    CupertinoListTile(
+                      leading: Icon(CupertinoIcons.person_crop_circle_badge_xmark),
+                      title: Text(
+                        '탈퇴하기',
+                        style: TextStyle(color: CupertinoColors.systemRed),
+                      ),
+                      onTap: () {
+                        _showIOSDialog(
+                          context: context,
+                          title: "회원 탈퇴",
+                          body: '정말 탈퇴할까요?',
+                          onConfirm: () {
+
+                          },
+                        );
+                      },
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
+          ),
+          settingState.isLoading
+              ? GreenFieldLoadingWidget()
+              : SizedBox.shrink(),
+        ],
       ),
     );
   }

--- a/lib/src/views/setting/setting_view.dart
+++ b/lib/src/views/setting/setting_view.dart
@@ -171,15 +171,9 @@ class _SettingViewState extends ConsumerState<SettingView> {
                         leading: Icon(CupertinoIcons.square_arrow_right),
                         title: Text('로그인 하러 가기'),
                         onTap: () async {
-                          final result = await ref
-                              .read(settingViewModelProvider.notifier)
-                              .resetUser();
-
-                          switch (result) {
-                            case Success():
                               final reset = await ref
-                                  .read(onboardingViewModelProvider.notifier)
-                                  .resetUserState();
+                                  .read(settingViewModelProvider.notifier)
+                                  .resetUser();
 
                               switch (reset) {
                                 case Success():
@@ -201,21 +195,6 @@ class _SettingViewState extends ConsumerState<SettingView> {
                                   );
                               }
 
-                            case Failure(exception: final e):
-                              showDialog(
-                                context: context,
-                                builder: (context) => AlertDialog(
-                                  title: Text('익명 로그인 초기화 실패'),
-                                  content: Text('에러 발생: $e'),
-                                  actions: [
-                                    TextButton(
-                                      onPressed: () => Navigator.of(context).pop(),
-                                      child: Text('확인'),
-                                    ),
-                                  ],
-                                ),
-                              );
-                          }
                         }
                     ),
                     userState.value != null

--- a/lib/src/views/setting/setting_view.dart
+++ b/lib/src/views/setting/setting_view.dart
@@ -154,8 +154,30 @@ class _SettingViewState extends ConsumerState<SettingView> {
                           context: context,
                           title: "회원 탈퇴",
                           body: '정말 탈퇴할까요?',
-                          onConfirm: () {
+                          onConfirm: () async {
+                            final result = await ref
+                                .read(settingViewModelProvider.notifier)
+                                .deleteUser(userState.value?.id ?? '');
 
+                            switch (result) {
+                              case Success():
+                                context.go('/signIn');
+
+                              case Failure(exception: final e):
+                                showDialog(
+                                  context: context,
+                                  builder: (context) => AlertDialog(
+                                    title: Text('로그인 실패'),
+                                    content: Text('에러 발생: $e'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () => Navigator.of(context).pop(),
+                                        child: Text('확인'),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                            }
                           },
                         );
                       },

--- a/lib/src/views/setting/setting_view.dart
+++ b/lib/src/views/setting/setting_view.dart
@@ -107,7 +107,8 @@ class _SettingViewState extends ConsumerState<SettingView> {
                 ),
                 CupertinoListSection.insetGrouped(
                   children: [
-                    CupertinoListTile(
+                    userState.value != null
+                      ? CupertinoListTile(
                         leading: Icon(CupertinoIcons.square_arrow_left),
                       title: Text('로그아웃'),
                       onTap: () {
@@ -116,19 +117,41 @@ class _SettingViewState extends ConsumerState<SettingView> {
                           title: "로그아웃",
                           body: '정말 로그아웃할까요?',
                           onConfirm: () async {
-                            final result = await ref
-                                .read(settingViewModelProvider.notifier)
-                                .signOut();
+                            final reset = await ref
+                                .read(onboardingViewModelProvider.notifier)
+                                .resetUserState();
 
-                            switch (result) {
+                            switch (reset) {
                               case Success():
-                                context.go('/signIn');
+                                final result = await ref
+                                    .read(settingViewModelProvider.notifier)
+                                    .signOut();
+
+                                switch (result) {
+                                  case Success():
+                                    context.go('/signIn');
+
+                                  case Failure(exception: final e):
+                                    showDialog(
+                                      context: context,
+                                      builder: (context) => AlertDialog(
+                                        title: Text('로그아웃 실패'),
+                                        content: Text('에러 발생: $e'),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () => Navigator.of(context).pop(),
+                                            child: Text('확인'),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                }
 
                               case Failure(exception: final e):
                                 showDialog(
                                   context: context,
                                   builder: (context) => AlertDialog(
-                                    title: Text('로그인 실패'),
+                                    title: Text('로그아웃 실패'),
                                     content: Text('에러 발생: $e'),
                                     actions: [
                                       TextButton(
@@ -138,50 +161,82 @@ class _SettingViewState extends ConsumerState<SettingView> {
                                     ],
                                   ),
                                 );
+                                break;
                             }
                           },
                         );
                       }
-                    ),
-                    CupertinoListTile(
-                      leading: Icon(CupertinoIcons.person_crop_circle_badge_xmark),
-                      title: Text(
-                        '탈퇴하기',
-                        style: TextStyle(color: CupertinoColors.systemRed),
-                      ),
-                      onTap: () {
-                        _showIOSDialog(
-                          context: context,
-                          title: "회원 탈퇴",
-                          body: '정말 탈퇴할까요?',
-                          onConfirm: () async {
-                            final result = await ref
-                                .read(settingViewModelProvider.notifier)
-                                .deleteUser(userState.value?.id ?? '');
+                    )
+                      : CupertinoListTile(
+                        leading: Icon(CupertinoIcons.square_arrow_right),
+                        title: Text('로그인 하러 가기'),
+                        onTap: () async {
+                          final result = await ref
+                              .read(settingViewModelProvider.notifier)
+                              .resetUser();
 
-                            switch (result) {
-                              case Success():
-                                context.go('/signIn');
+                          switch (result) {
+                            case Success():
+                              context.go('/signIn');
 
-                              case Failure(exception: final e):
-                                showDialog(
-                                  context: context,
-                                  builder: (context) => AlertDialog(
-                                    title: Text('로그인 실패'),
-                                    content: Text('에러 발생: $e'),
-                                    actions: [
-                                      TextButton(
-                                        onPressed: () => Navigator.of(context).pop(),
-                                        child: Text('확인'),
-                                      ),
-                                    ],
-                                  ),
-                                );
-                            }
-                          },
-                        );
-                      },
+                            case Failure(exception: final e):
+                              showDialog(
+                                context: context,
+                                builder: (context) => AlertDialog(
+                                  title: Text('익명 로그인 초기화 실패'),
+                                  content: Text('에러 발생: $e'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.of(context).pop(),
+                                      child: Text('확인'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                          }
+                        }
                     ),
+                    userState.value != null
+                        ? CupertinoListTile(
+                            leading: Icon(CupertinoIcons.person_crop_circle_badge_xmark),
+                            title: Text(
+                              '탈퇴하기',
+                              style: TextStyle(color: CupertinoColors.systemRed),
+                            ),
+                            onTap: () {
+                              _showIOSDialog(
+                                context: context,
+                                title: "회원 탈퇴",
+                                body: '정말 탈퇴할까요?',
+                                onConfirm: () async {
+                                  final result = await ref
+                                      .read(settingViewModelProvider.notifier)
+                                      .deleteUser(userState.value?.id ?? '');
+
+                                  switch (result) {
+                                    case Success():
+                                      context.go('/signIn');
+
+                                    case Failure(exception: final e):
+                                      showDialog(
+                                        context: context,
+                                        builder: (context) => AlertDialog(
+                                          title: Text('로그인 실패'),
+                                          content: Text('에러 발생: $e'),
+                                          actions: [
+                                            TextButton(
+                                              onPressed: () => Navigator.of(context).pop(),
+                                              child: Text('확인'),
+                                            ),
+                                          ],
+                                        ),
+                                      );
+                                  }
+                                },
+                              );
+                            },
+                          )
+                        : SizedBox.shrink()
                   ],
                 ),
               ],

--- a/lib/src/views/setting/setting_view.dart
+++ b/lib/src/views/setting/setting_view.dart
@@ -177,7 +177,29 @@ class _SettingViewState extends ConsumerState<SettingView> {
 
                           switch (result) {
                             case Success():
-                              context.go('/signIn');
+                              final reset = await ref
+                                  .read(onboardingViewModelProvider.notifier)
+                                  .resetUserState();
+
+                              switch (reset) {
+                                case Success():
+                                  context.go('/signIn');
+
+                                case Failure(exception: final e):
+                                  showDialog(
+                                    context: context,
+                                    builder: (context) => AlertDialog(
+                                      title: Text('익명 로그인 초기화 실패'),
+                                      content: Text('에러 발생: $e'),
+                                      actions: [
+                                        TextButton(
+                                          onPressed: () => Navigator.of(context).pop(),
+                                          child: Text('확인'),
+                                        ),
+                                      ],
+                                    ),
+                                  );
+                              }
 
                             case Failure(exception: final e):
                               showDialog(


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->

### 기능 추가 및 개선

- **SettingViewModel 구현 및 사용자 로그아웃 기능 추가**
  - 사용자 설정을 관리할 수 있는 `SettingViewModel`을 구현하고, 로그아웃 기능을 추가했습니다.

- **카카오 로그인 통합**
  - 웹 및 모바일 플랫폼에서 카카오 로그인을 통합하여 사용자 인증을 강화했습니다.

- **사용자 계정 삭제 기능 구현**
  - 사용자가 자신의 계정을 삭제할 수 있는 기능을 구현했습니다.

- **익명 로그인 기능 구현**
  - 익명 로그인 기능을 추가하여 사용자가 간편하게 서비스를 체험할 수 있도록 했습니다.

### 디자인 및 코드 정리

- **이미지 상세 UI 변경**
  - 이미지 상세 보기 화면의 UI를 개선하여 사용자 경험을 향상시켰습니다.

- **사용하지 않는 코드 제거**
  - 로그인 관련 사용하지 않는 코드를 정리하여 코드베이스를 깔끔하게 유지했습니다.

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
| 익명 로그인 기능 |<img src = "https://github.com/user-attachments/assets/f55fafc8-55f1-460a-8cc6-6732fbbc179b" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
