### PR TITLE
[fix]: Fix empty screen issue after auto-deletion of recruitment posts

### DIFF
--- a/lib/src/views/home/sections/expiring_soon_recruit_section.dart
+++ b/lib/src/views/home/sections/expiring_soon_recruit_section.dart
@@ -24,7 +24,7 @@ class _ExpiringSoonRecruitSectionState extends ConsumerState<ExpiringSoonRecruit
     final userState = ref.watch(onboardingViewModelProvider);
     final recruitState = ref.watch(recruitViewModelProvider);
 
-    return ((recruitState.value != null && recruitState.value! == [] ))
+    return ((recruitState.value != null && recruitState.value!.isNotEmpty ))
         ? Flexible(
             child: Padding(
               padding: const EdgeInsets.only(bottom: 15.0),
@@ -34,8 +34,7 @@ class _ExpiringSoonRecruitSectionState extends ConsumerState<ExpiringSoonRecruit
                 itemBuilder: (context, index) {
                   final recruit = recruitState.value?[index];
                   return (recruit != null)
-                      ? DateTime.now().isBefore(recruit.remainTime)
-                          ? GreenFieldExpiringSoonList(
+                      ?  GreenFieldExpiringSoonList(
                           title: recruit.title,
                           body: recruit.body,
                           remainTime: '${DateTime.now().difference(recruit!.remainTime).inMinutes.abs()}',
@@ -58,8 +57,7 @@ class _ExpiringSoonRecruitSectionState extends ConsumerState<ExpiringSoonRecruit
                             }
                           },
                         )
-                          : SizedBox.shrink()
-                  : Image.asset(AppIcons.networkSesac, width: 300);
+                    : Image.asset(AppIcons.networkSesac, width: 300);
                 },
               ),
             ),

--- a/lib/src/views/home/sections/expiring_soon_recruit_section.dart
+++ b/lib/src/views/home/sections/expiring_soon_recruit_section.dart
@@ -24,7 +24,7 @@ class _ExpiringSoonRecruitSectionState extends ConsumerState<ExpiringSoonRecruit
     final userState = ref.watch(onboardingViewModelProvider);
     final recruitState = ref.watch(recruitViewModelProvider);
 
-    return ((recruitState.value != null && recruitState.value!.isNotEmpty ))
+    return ((recruitState.value != null && recruitState.value! == [] ))
         ? Flexible(
             child: Padding(
               padding: const EdgeInsets.only(bottom: 15.0),

--- a/lib/src/views/recruitment/recruitment_detail_view.dart
+++ b/lib/src/views/recruitment/recruitment_detail_view.dart
@@ -139,15 +139,22 @@ class _RecruitDetailViewState extends ConsumerState<RecruitDetailView> {
                           case Success(value: final recruit):
                             if (DateTime.now().isBefore(recruit.remainTime)) {
                               if (recruitNotifier.isEntryChatRoomActive(recruit.currentParticipants.length, recruit.maxParticipants)) {
-                                final entryResult = await ref.read(recruitViewModelProvider.notifier).entryChatRoom(currentRecruit.id, userState.value?.id ?? '');
+                                final entryResult = await ref.read(
+                                    recruitViewModelProvider.notifier)
+                                    .entryChatRoom(currentRecruit.id,
+                                    userState.value?.id ?? '');
 
                                 switch (entryResult) {
                                   case Success():
                                     context.go('/recruit/chat/${recruit.id}');
                                   case Failure(exception: final e):
-                                    recruitEditNotifier.flutterToast('에러가 발생했어요!');
+                                    recruitEditNotifier.flutterToast(
+                                        '에러가 발생했어요!');
                                 }
-                              } else {
+                              } else if (currentRecruit.currentParticipants.contains(userState.value?.id ?? '')) {
+                                context.go('/recruit/chat/${currentRecruit.id}');
+                              }
+                              else {
                                 recruitEditNotifier.flutterToast('채팅방에 인원이 모두 찼어요.');
                               }
                             } else {


### PR DESCRIPTION
## 🛠️ 작업 내용
<!-- 작업 내용 (스크린샷도 같이 있으면 좋아요) -->
### 모집글 자동 삭제 후 빈 화면 이슈

풀밭에서 모집글은 시간과 최대 인원 수가 정해져 있습니다.

만약 제한 시간이 지난다면 모집글에 더 이상 들어갈 수 없습니다.

이 때 이슈가 발생하였는데 모집글이 자동으로 삭제되면서 빈 화면이 보여지는 이슈가 발생하였습니다.

설계대로 라면 오른쪽 화면 처럼 모집글이 없을때 표시되는 UI가 있어야 합니다.
<br>

<br>

## 📱 작업 화면
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|화면 이름|스크린샷|
|:--:|:--:|
|모집글 자동 삭제 오류 해결|<img src = "https://github.com/user-attachments/assets/56912533-b60a-45b5-aa2b-9202751fe00f" width ="250">|
|모집글 자동 삭제 오류 |<img src = "https://github.com/user-attachments/assets/0d1623ec-a79b-4099-b5d5-34f1296d6a3f" width ="250">|

<br>

## 🗒️ Note (optional)
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
